### PR TITLE
fix: pull image in docker builder

### DIFF
--- a/pkg/driverbuilder/docker.go
+++ b/pkg/driverbuilder/docker.go
@@ -90,6 +90,12 @@ func (bp *DockerBuildProcessor) Start(b *builder.Build) error {
 	ctx := context.Background()
 	ctx = signals.WithStandardSignals(ctx)
 
+	_, err = cli.ImagePull(ctx, builderBaseImage, types.ImagePullOptions{})
+
+	if err != nil {
+		return err
+	}
+
 	containerCfg := &container.Config{
 		Tty:   true,
 		Cmd:   []string{"/bin/sleep", strconv.Itoa(bp.timeout)},


### PR DESCRIPTION
Co-Authored-By: Leonardo Di Donato <leodidonato@gmail.com>
Signed-off-by: Lorenzo Fontana <lo@linux.com>



**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area pkg

**What this PR does / why we need it**:

Pull the driverkit-builder docker image (docker processor).

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
update: pull the driverkit-builder docker image while building with docker processor
```
