### PR TITLE
options validation improvements + fix for docker image pull

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,6 +54,8 @@ func persistentValidateFunc(rootCommand *cobra.Command, rootOpts *RootOptions) f
 				logger.Fatal("exiting for validation errors")
 			}
 		}
+
+		rootOpts.Log()
 	}
 }
 
@@ -81,7 +83,7 @@ func NewRootCmd() *cobra.Command {
 	flags.StringVar(&rootOpts.Output.Module, "output-module", rootOpts.Output.Module, "filepath where to save the resulting kernel module")
 	flags.StringVar(&rootOpts.Output.Probe, "output-probe", rootOpts.Output.Probe, "filepath where to save the resulting eBPF probe")
 
-	flags.StringVar(&rootOpts.DriverVersion, "driverversion", rootOpts.DriverVersion, "driver version as a git reference")
+	flags.StringVar(&rootOpts.DriverVersion, "driverversion", rootOpts.DriverVersion, "driver version as a git commit hash or as a git tag")
 	flags.Uint16Var(&rootOpts.KernelVersion, "kernelversion", rootOpts.KernelVersion, "kernel version to build the module for, it's the numeric value after the hash when you execute 'uname -v'")
 	flags.StringVar(&rootOpts.KernelRelease, "kernelrelease", rootOpts.KernelRelease, "kernel release to build the module for, it can be found by executing 'uname -v'")
 	flags.StringVarP(&rootOpts.Target, "target", "t", rootOpts.Target, "the system to target the build for")

--- a/cmd/root_options.go
+++ b/cmd/root_options.go
@@ -20,8 +20,8 @@ type OutputOptions struct {
 type RootOptions struct {
 	Architecture     string `default:"x86_64" validate:"required,oneof=x86_64" name:"architecture"`
 	DriverVersion    string `default:"dev" validate:"required,eq=dev|sha1|semver" name:"driver version"`
-	KernelVersion    uint16 `validate:"omitempty,number" name:"kernel version"` // todo > default 1?
-	KernelRelease    string `validate:"required,ascii" name:"kernel release"`   // todo > semver validator?
+	KernelVersion    uint16 `default:"1" validate:"omitempty,number" name:"kernel version"`
+	KernelRelease    string `validate:"required,ascii" name:"kernel release"`               // todo > semver validator?
 	Target           string `validate:"required,target" name:"target"`
 	KernelConfigData string `validate:"omitempty,base64" name:"kernel config data"` // fixme > tag "name" does not seem to work when used at struct level, but works when used at inner level
 	Output           OutputOptions

--- a/cmd/root_options.go
+++ b/cmd/root_options.go
@@ -19,9 +19,9 @@ type OutputOptions struct {
 // RootOptions ...
 type RootOptions struct {
 	Architecture     string `default:"x86_64" validate:"required,oneof=x86_64" name:"architecture"`
-	DriverVersion    string `default:"dev" validate:"required,eq=dev|sha1" name:"driver version"`
-	KernelVersion    uint16 `validate:"omitempty,number" name:"kernel version"` // todo > semver validator?
-	KernelRelease    string `validate:"required,ascii" name:"kernel release"`
+	DriverVersion    string `default:"dev" validate:"required,eq=dev|sha1|semver" name:"driver version"`
+	KernelVersion    uint16 `validate:"omitempty,number" name:"kernel version"` // todo > default 1?
+	KernelRelease    string `validate:"required,ascii" name:"kernel release"`   // todo > semver validator?
 	Target           string `validate:"required,target" name:"target"`
 	KernelConfigData string `validate:"omitempty,base64" name:"kernel config data"` // fixme > tag "name" does not seem to work when used at struct level, but works when used at inner level
 	Output           OutputOptions

--- a/cmd/root_options.go
+++ b/cmd/root_options.go
@@ -54,6 +54,26 @@ func (ro *RootOptions) Validate() []error {
 	return nil
 }
 
+// Log emits a log line containing the receiving RootOptions for debugging purposes.
+//
+// Call it only after validation.
+func (ro *RootOptions) Log() {
+	fields := logger.Fields{}
+	if ro.Output.Module != "" {
+		fields["output-module"] = ro.Output.Module
+	}
+	if ro.Output.Probe != "" {
+		fields["output-probe"] = ro.Output.Probe
+
+	}
+	fields["driverversion"] = ro.DriverVersion
+	fields["kernelrelease"] = ro.KernelRelease
+	fields["kernelversion"] = ro.KernelVersion
+	fields["target"] = ro.Target
+
+	logger.WithFields(fields).Debug("running with options")
+}
+
 func (ro *RootOptions) toBuild() *builder.Build {
 	kernelConfigData := ro.KernelConfigData
 	if len(kernelConfigData) == 0 {

--- a/cmd/root_options.go
+++ b/cmd/root_options.go
@@ -21,7 +21,7 @@ type RootOptions struct {
 	Architecture     string `default:"x86_64" validate:"required,oneof=x86_64" name:"architecture"`
 	DriverVersion    string `default:"dev" validate:"required,eq=dev|sha1|semver" name:"driver version"`
 	KernelVersion    uint16 `default:"1" validate:"omitempty,number" name:"kernel version"`
-	KernelRelease    string `validate:"required,ascii" name:"kernel release"`               // todo > semver validator?
+	KernelRelease    string `validate:"required,ascii" name:"kernel release"`
 	Target           string `validate:"required,target" name:"target"`
 	KernelConfigData string `validate:"omitempty,base64" name:"kernel config data"` // fixme > tag "name" does not seem to work when used at struct level, but works when used at inner level
 	Output           OutputOptions

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/falcosecurity/driverkit
 go 1.13
 
 require (
+	github.com/Masterminds/semver/v3 v3.0.3
 	github.com/Microsoft/go-winio v0.4.14 // indirect
 	github.com/creasty/defaults v1.3.0
 	github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd h1:sjQovDkwrZp8u+gxLtPgKGjk5hCxuy2hrRejBTA9xFU=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
+github.com/Masterminds/semver/v3 v3.0.3 h1:znjIyLfpXEDQjOIEWh+ehwpTU14UzUPub3c3sm36u14=
+github.com/Masterminds/semver/v3 v3.0.3/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Microsoft/go-winio v0.4.14 h1:+hMXMk01us9KgxGb7ftKQt2Xpf5hH/yky+TDA+qxleU=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=

--- a/pkg/driverbuilder/docker.go
+++ b/pkg/driverbuilder/docker.go
@@ -90,7 +90,7 @@ func (bp *DockerBuildProcessor) Start(b *builder.Build) error {
 	ctx := context.Background()
 	ctx = signals.WithStandardSignals(ctx)
 
-	_, err = cli.ImagePull(ctx, builderBaseImage, types.ImagePullOptions{})
+	_, err = cli.ImagePull(ctx, builderBaseImage, types.ImagePullOptions{All: true})
 
 	if err != nil {
 		return err

--- a/validate/semver.go
+++ b/validate/semver.go
@@ -1,0 +1,21 @@
+package validate
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/go-playground/validator/v10"
+)
+
+func isSemVer(fl validator.FieldLevel) bool {
+	field := fl.Field()
+
+	switch field.Kind() {
+	case reflect.String:
+		_, err := semver.NewVersion(field.String())
+		return err == nil
+	}
+
+	panic(fmt.Sprintf("Bad field type %T", field.Interface()))
+}

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -122,6 +122,19 @@ func init() {
 	)
 
 	V.RegisterTranslation(
+		"semver",
+		T,
+		func(ut ut.Translator) error {
+			return ut.Add("semver", "{0} must be a semver-ish string", true)
+		},
+		func(ut ut.Translator, fe validator.FieldError) string {
+			t, _ := ut.T(fe.Tag(), fe.Field())
+
+			return t
+		},
+	)
+
+	V.RegisterTranslation(
 		"required_without",
 		T,
 		func(ut ut.Translator) error {

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -36,6 +36,7 @@ func init() {
 	V.RegisterValidation("filepath", isFilePath)
 	V.RegisterValidation("sha1", isSHA1)
 	V.RegisterValidation("target", isTargetSupported)
+	V.RegisterValidation("semver", isSemVer)
 
 	eng := en.New()
 	uni := ut.New(eng, eng)
@@ -108,13 +109,13 @@ func init() {
 	)
 
 	V.RegisterTranslation(
-		"eq=dev|sha1",
+		"eq=dev|sha1|semver",
 		T,
 		func(ut ut.Translator) error {
-			return ut.Add("eq=dev|sha1", "{0} must be a valid SHA1 or dev", true)
+			return ut.Add("eq=dev|sha1|semver", `{0} must be a valid SHA1, semver-ish, or the "dev" string`, true)
 		},
 		func(ut ut.Translator, fe validator.FieldError) string {
-			t, _ := ut.T("eq=dev|sha1", fe.Field())
+			t, _ := ut.T(fe.Tag(), fe.Field())
 
 			return t
 		},


### PR DESCRIPTION


**What type of PR is this?**

/kind bug



/kind feature



**Any specific area of the project related to this PR?**




/area cmd

/area pkg




**What this PR does / why we need it**:

This PR makes the image pull honor the common docker behavior for image pulls.

Also, this PR introduces the ability to specify semver-ish tags as `driverversion` options.

**Which issue(s) this PR fixes**:


Fixes #33 
Fixes #34

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
fix: honor docker image pull behaviour
update: accept semver-ish strings as driver version option values
```
