### PR TITLE
fix(cmd): correct options precedence and support for flags containing dashes

### DIFF
--- a/cmd/config_options.go
+++ b/cmd/config_options.go
@@ -9,6 +9,7 @@ import (
 	logger "github.com/sirupsen/logrus"
 )
 
+var validProcessors = []string{"docker", "kubernetes"}
 var configOptions *ConfigOptions
 
 // ConfigOptions represent the persistent configuration flags of driverkit.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,6 +59,8 @@ func NewRootCmd() *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:                   "driverkit",
 		Short:                 "A command line tool to build Falco kernel modules and eBPF probes.",
+		ValidArgs: []string{"docker", "kubernetes"},
+		Args: cobra.OnlyValidArgs,
 		DisableFlagsInUseLine: true,
 		Run: func(c *cobra.Command, args []string) {
 			// Fallback to help

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,9 +47,8 @@ func persistentValidateFunc(rootCommand *cobra.Command, rootOpts *RootOptions) f
 				}
 				logger.Fatal("exiting for validation errors")
 			}
+			rootOpts.Log()
 		}
-
-		rootOpts.Log()
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,10 +59,13 @@ func NewRootCmd() *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:                   "driverkit",
 		Short:                 "A command line tool to build Falco kernel modules and eBPF probes.",
-		ValidArgs: []string{"docker", "kubernetes"},
-		Args: cobra.OnlyValidArgs,
+		ValidArgs:             validProcessors,
+		Args:                  cobra.OnlyValidArgs,
 		DisableFlagsInUseLine: true,
 		Run: func(c *cobra.Command, args []string) {
+			if len(args) == 0 {
+				logger.WithField("processors", validProcessors).Info("specify the processor")
+			}
 			// Fallback to help
 			c.Help()
 		},

--- a/cmd/root_options.go
+++ b/cmd/root_options.go
@@ -66,10 +66,18 @@ func (ro *RootOptions) Log() {
 		fields["output-probe"] = ro.Output.Probe
 
 	}
-	fields["driverversion"] = ro.DriverVersion
-	fields["kernelrelease"] = ro.KernelRelease
-	fields["kernelversion"] = ro.KernelVersion
-	fields["target"] = ro.Target
+	if ro.DriverVersion != "" {
+		fields["driverversion"] = ro.DriverVersion
+	}
+	if ro.KernelRelease != "" {
+		fields["kernelrelease"] = ro.KernelRelease
+	}
+	if ro.KernelVersion > 0 {
+		fields["kernelversion"] = ro.KernelVersion
+	}
+	if ro.Target != "" {
+		fields["target"] = ro.Target
+	}
 
 	logger.WithFields(fields).Debug("running with options")
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area cmd

> /area pkg

> /area docs

> /area tests


**What this PR does / why we need it**:

This PR corrects the logic of how `RootOptions` are fetched and merged. 

Now, each item takes precedence over the item below it:
- flag
- env
- config
- default 

Also:
- fields present in `ConfigOptions` are skipped, and can only be set using command line flags
- nested flags from config file are supported too
- not-nested flags containing `-` in their name work too

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->
This PR also indirectly
Fixes #43 

**Special notes for your reviewer**:
/assign @leodido 

Below you can find some useful tests. 
NOTE: I temporarily added a fake flag (`--test-flag`) and printed out `RootOptions` just for testing purpose

`config.yaml`
```
test-flag: "from-config"
```

From config
```
$ _output/bin/driverkit -c ./config.yaml docker --loglevel debug 
INFO[0000] using config file                             file=./config.yaml
ERRO[0000] error validating build options                error="kernel release is a required field"
ERRO[0000] error validating build options                error="target is a required field"
ERRO[0000] error validating build options                error="output module path is required when probe is missing"
ERRO[0000] error validating build options                error="output probe path is required when module is missing"
DEBU[0000] running with options                          driverversion=dev kernelrelease= kernelversion=1 target=
cmd.RootOptions{Architecture:"x86_64", DriverVersion:"dev", KernelVersion:0x1, KernelRelease:"", Target:"", KernelConfigData:"", Output:cmd.OutputOptions{Module:"", Probe:""}, TestFlag:"from-config"}
```

Override from ENV
```
$ DRIVERKIT_TEST_FLAG=from-env _output/bin/driverkit -c ./config.yaml docker --loglevel debug 
INFO[0000] using config file                             file=./config.yaml
ERRO[0000] error validating build options                error="kernel release is a required field"
ERRO[0000] error validating build options                error="target is a required field"
ERRO[0000] error validating build options                error="output module path is required when probe is missing"
ERRO[0000] error validating build options                error="output probe path is required when module is missing"
DEBU[0000] running with options                          driverversion=dev kernelrelease= kernelversion=1 target=
cmd.RootOptions{Architecture:"x86_64", DriverVersion:"dev", KernelVersion:0x1, KernelRelease:"", Target:"", KernelConfigData:"", Output:cmd.OutputOptions{Module:"", Probe:""}, TestFlag:"from-env"}
```

Override from flag
```
$ DRIVERKIT_TEST_FLAG=from-env _output/bin/driverkit -c ./config.yaml docker --loglevel debug --test-flag from-flag
INFO[0000] using config file                             file=./config.yaml
ERRO[0000] error validating build options                error="kernel release is a required field"
ERRO[0000] error validating build options                error="target is a required field"
ERRO[0000] error validating build options                error="output module path is required when probe is missing"
ERRO[0000] error validating build options                error="output probe path is required when module is missing"
DEBU[0000] running with options                          driverversion=dev kernelrelease= kernelversion=1 target=
cmd.RootOptions{Architecture:"x86_64", DriverVersion:"dev", KernelVersion:0x1, KernelRelease:"", Target:"", KernelConfigData:"", Output:cmd.OutputOptions{Module:"", Probe:""}, TestFlag:"from-flag"}
```

`uint16` from ENV
```
$ DRIVERKIT_KERNELVERSION=2 _output/bin/driverkit docker 
ERRO[0000] error validating build options                error="kernel release is a required field"
ERRO[0000] error validating build options                error="target is a required field"
ERRO[0000] error validating build options                error="output module path is required when probe is missing"
ERRO[0000] error validating build options                error="output probe path is required when module is missing"
cmd.RootOptions{Architecture:"x86_64", DriverVersion:"dev", KernelVersion:0x2, KernelRelease:"", Target:"", KernelConfigData:"", Output:cmd.OutputOptions{Module:"", Probe:""}, TestFlag:""}
```

`uint16` from flag
```
$ _output/bin/driverkit docker --kernelversion 4
ERRO[0000] error validating build options                error="kernel release is a required field"
ERRO[0000] error validating build options                error="target is a required field"
ERRO[0000] error validating build options                error="output module path is required when probe is missing"
ERRO[0000] error validating build options                error="output probe path is required when module is missing"
cmd.RootOptions{Architecture:"x86_64", DriverVersion:"dev", KernelVersion:0x4, KernelRelease:"", Target:"", KernelConfigData:"", Output:cmd.OutputOptions{Module:"", Probe:""}, TestFlag:""}
```

`vanilla.yaml`
```
kernelrelease: 5.5.13-arch1-1
kernelversion: 1
target: vanilla
output:
  module: /tmp/falco-vanilla.ko
  probe: /tmp/falco-vanilla.o
driverversion: dev
kernelconfigdata: 
...
```

From config:
```
$ _output/bin/driverkit -c ./vanilla.yaml docker --loglevel debug
INFO[0000] using config file                             file=./vanilla.yaml
DEBU[0000] running with options                          driverversion=dev kernelrelease=5.5.13-arch1-1 kernelversion=1 output-module=/tmp/falco-vanilla.ko output-probe=/tmp/falco-vanilla.o target=vanilla
```

Override nested field (ENV)
```
$ DRIVERKIT_OUTPUT_MODULE=/tmp/falco_from_env.ko _output/bin/driverkit -c ./vanilla.yaml docker --loglevel debug 
INFO[0000] using config file                             file=./vanilla.yaml
DEBU[0000] running with options                          driverversion=dev kernelrelease=5.5.13-arch1-1 kernelversion=1 output-module=/tmp/falco_from_env.ko output-probe=/tmp/falco-vanilla.o target=vanilla
```

Override nested field (flag)
```
DRIVERKIT_OUTPUT_MODULE=/tmp/falco_from_env.ko _output/bin/driverkit -c ./vanilla.yaml docker --loglevel debug --output-module=/tmp/falco-from-flag.ko
INFO[0000] using config file                             file=./vanilla.yaml
DEBU[0000] running with options                          driverversion=dev kernelrelease=5.5.13-arch1-1 kernelversion=1 output-module=/tmp/falco-from-flag.ko output-probe=/tmp/falco-vanilla.o target=vanilla
```

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
