### PR TITLE
Refinements to ubuntu targets

### DIFF
--- a/pkg/driverbuilder/builder/ubuntu.go
+++ b/pkg/driverbuilder/builder/ubuntu.go
@@ -123,6 +123,7 @@ func ubuntuGenericHeadersURLFromRelease(kr kernelrelease.KernelRelease, kv uint1
 			return urls, err
 		}
 	}
+
 	return nil, fmt.Errorf("kernel headers not found")
 }
 
@@ -163,7 +164,7 @@ func fetchUbuntuAWSKernelURLS(baseURL string, kr kernelrelease.KernelRelease, ke
 			kernelVersion,
 		),
 		fmt.Sprintf(
-			"%s/linux-aws-headers-%s%s_%s-%s.%d_amd64.deb",
+			"%s/linux-headers-%s%s_%s-%s.%d_amd64.deb",
 			baseURL,
 			kr.Fullversion,
 			kr.FullExtraversion,
@@ -246,7 +247,10 @@ ls -l probe.o
 func ubuntuGCCVersionFromKernelRelease(kr kernelrelease.KernelRelease) string {
 	switch kr.Version {
 	case "3":
-		return "5"
+		if kr.PatchLevel == "13" || kr.PatchLevel == "2" {
+			return "4.8"
+		}
+		return "6"
 	}
 	return "8"
 }


### PR DESCRIPTION

**What type of PR is this?**

/kind bug



**Any specific area of the project related to this PR?**



/area pkg




**What this PR does / why we need it**:

It adds "security.ubuntu.com/ubuntu/pool/main/l" base URLs for ubuntu-generic and ubunut-aws targets.

Moreover, it changes the GCC version in use depending on the kernel version for which the Falco module is being built.

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:



```release-note
update(pkg/driverbuilder/builder/ubuntu): security.ubuntu.com/ubuntu/pool/main/l as base url for ubuntu-aws and ubuntu-generic targets
fix(pkg/driverbuilder/builder/ubuntu): some 3.x kernels needs an older GCC 
```
