### PR TITLE
Fix discovery of kernel headers for ubuntu-aws-*.*

### DIFF
--- a/pkg/driverbuilder/builder/ubuntu.go
+++ b/pkg/driverbuilder/builder/ubuntu.go
@@ -112,7 +112,7 @@ func ubuntuAWSHeadersURLFromRelease(kr kernelrelease.KernelRelease, kv uint16) (
 		}
 	}
 
-	// If we can't find the aws files in the main folders,
+	// If we can't find the AWS files in the main folders,
 	// try to proactively parse the subfolders to find what we need
 	for _, u := range baseURL {
 		url := fmt.Sprintf("%s-%s.%s", u, kr.Version, kr.PatchLevel)
@@ -205,8 +205,8 @@ func parseUbuntuAWSKernelURLS(baseURL string, kr kernelrelease.KernelRelease, ke
 		return nil, err
 	}
 	firstExtra := extractExtraNumber(kr.Extraversion)
-	rmatch := `href="(linux(?:-aws)?-headers-%s-%s(?:-aws)?_%s-%s\.%d.*(?:amd64|all)\.deb)"`
-	fullRegex := fmt.Sprintf(rmatch, kr.Fullversion, firstExtra, kr.Fullversion, firstExtra, kernelVersion)
+	rmatch := `href="(linux(?:-aws-%s.%s)?-headers-%s-%s(?:-aws)?_%s-%s\.%d.*(?:amd64|all)\.deb)"`
+	fullRegex := fmt.Sprintf(rmatch, kr.Version, kr.PatchLevel, kr.Fullversion, firstExtra, kr.Fullversion, firstExtra, kernelVersion)
 	pattern := regexp.MustCompile(fullRegex)
 	matches := pattern.FindAllStringSubmatch(string(body), 2)
 	if len(matches) != 2 {


### PR DESCRIPTION


Co-Authored-by: Lorenzo Fontana <lo@linux.com>
Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>



**What type of PR is this?**


/kind bug


**Any specific area of the project related to this PR?**



/area pkg




**What this PR does / why we need it**:

Correct regex to find all the `ubuntu-aws-*.*-...` kernel headers in nested folders

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Refs https://github.com/falcosecurity/test-infra/pull/172

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
fix: discovery of kernel headers for ubuntu-aws-*.* works correctly now
```
