### PR TITLE
update(pkg/driverbuilder): debian support for cloud-amd64 extraversion

### DIFF
--- a/pkg/driverbuilder/builder/debian.go
+++ b/pkg/driverbuilder/builder/debian.go
@@ -158,9 +158,19 @@ func debianHeadersURLFromRelease(kr kernelrelease.KernelRelease) ([]string, erro
 }
 
 func fetchDebianHeadersURLFromRelease(baseURL string, kr kernelrelease.KernelRelease) ([]string, error) {
+	rmatch := `href="(linux-headers-%s\.%s\.%s%s-(%s)_.*(amd64|all)\.deb)"`
+
+	// match for kernel versions like 4.19.0-6-amd64
 	extraVersionPartial := strings.TrimSuffix(kr.FullExtraversion, "-amd64")
-	rmatch := `href="(linux-headers-%s\.%s\.%s%s-(amd64|common)_.*(amd64|all)\.deb)"`
-	fullregex := fmt.Sprintf(rmatch, kr.Version, kr.PatchLevel, kr.Sublevel, extraVersionPartial)
+	matchExtraGroup := "amd64|common"
+
+	// match for kernel versions like 4.19.0-6-cloud-amd64
+	if strings.Contains(kr.FullExtraversion, "-cloud") {
+		extraVersionPartial = strings.TrimSuffix(extraVersionPartial, "-cloud")
+		matchExtraGroup = "cloud-amd64|common"
+	}
+
+	fullregex := fmt.Sprintf(rmatch, kr.Version, kr.PatchLevel, kr.Sublevel, extraVersionPartial, matchExtraGroup)
 	pattern := regexp.MustCompile(fullregex)
 	resp, err := http.Get(baseURL)
 	if err != nil {


### PR DESCRIPTION
Co-Authored-By: Leonardo Di Donato <leodidonato@gmail.com>
Signed-off-by: Lorenzo Fontana <fontanalorenz@gmail.com>

**What type of PR is this?**

/kind feature


**Any specific area of the project related to this PR?**



/area pkg


**What this PR does / why we need it**:

@danpopSD reported that they wanted to try Falco on a  `4.19.0-10-cloud-amd64` kernel.

This PR makes sure that driverkit does not ignore the `cloud` extraversion and thus can build for said kernel group.

![image](https://user-images.githubusercontent.com/3083633/94674042-e40b2980-0317-11eb-91ee-6a25e819a51c.png)


**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
new: build support for debian cloud-amd64 kernels
```
