### PR TITLE
docs: release md specify that v is needed in the versioning scheme of the tag

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,12 +11,12 @@ When we release we do the following process:
 
 ## Release commands
 
-Tag the version
+Tag the version, keep the `v` and replace `x.y.z` with the version number. e.g: `0.2.0`
 
 ```bash
 git pull
 git checkout master
-git tag x.y.z
-git push origin x.y.z
+git tag vx.y.z
+git push origin vx.y.z
 ```
 > N.B.: do NOT use an annotated tag


### PR DESCRIPTION
Signed-off-by: Lorenzo Fontana <fontanalorenz@gmail.com>


**What type of PR is this?**


/kind documentation

**Any specific area of the project related to this PR?**


/area docs




**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
I was doing a release nad noticed that the `RELEASE.md` docs didn't mention the `v` in the versioning scheme which is actually required for the CI to work and also used in the previous releases.

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
