### PR TITLE
new: support for GKE kernels in the ubuntu-generic builder

### DIFF
--- a/pkg/kernelrelease/kernelrelease.go
+++ b/pkg/kernelrelease/kernelrelease.go
@@ -2,6 +2,7 @@ package kernelrelease
 
 import (
 	"regexp"
+	"strings"
 )
 
 var (
@@ -16,6 +17,11 @@ type KernelRelease struct {
 	Sublevel         string
 	Extraversion     string
 	FullExtraversion string
+}
+
+// IsGKE tells whether the current kernel release is for GKE by looking at its name.
+func (kr *KernelRelease) IsGKE() bool {
+	return strings.HasSuffix(kr.Extraversion, "gke")
 }
 
 // FromString extracts a KernelRelease object from string.

--- a/pkg/kernelrelease/kernelrelease_test.go
+++ b/pkg/kernelrelease/kernelrelease_test.go
@@ -110,6 +110,17 @@ func TestFromString(t *testing.T) {
 				FullExtraversion: "-136.231.amzn2.x86_64",
 			},
 		},
+		"gke version": {
+			kernelVersionStr: "4.15.0-1044-gke",
+			want: KernelRelease{
+				Fullversion:      "4.15.0",
+				Version:          "4",
+				PatchLevel:       "15",
+				Sublevel:         "0",
+				Extraversion:     "1044-gke",
+				FullExtraversion: "-1044-gke",
+			},
+		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug
/kind feature

**Any specific area of the project related to this PR?**

/area pkg

**What this PR does / why we need it**:

Add supports for GKE kernels to the already existing ubuntu-generic builder.

**Which issue(s) this PR fixes**:

Fixes #67
Fixes #60

**Special notes for your reviewer**:

To help the reviewer I provide a YAML configuration file:

```yaml
kernelversion: 46
kernelrelease: 4.15.0-1044-gke
target: ubuntu-generic
output:
  module: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1044-gke_46.ko
  probe: output/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_ubuntu-generic_4.15.0-1044-gke_46.o
```

**Does this PR introduce a user-facing change?**:

```release-note
new: support for GKE kernels in the ubuntu-generic builder
```
