### PR TITLE
Support also GKE 5.4 kernels (ubuntu-generic builder)

### DIFF
--- a/pkg/driverbuilder/builder/ubuntu.go
+++ b/pkg/driverbuilder/builder/ubuntu.go
@@ -156,6 +156,7 @@ func fetchUbuntuGenericKernelURL(baseURL string, kr kernelrelease.KernelRelease,
 	firstExtra := extractExtraNumber(kr.Extraversion)
 	if kr.IsGKE() {
 		return []string{
+			// For 4.15 GKE kernels
 			fmt.Sprintf(
 				"%s/linux-gke-%s.%s-headers-%s-%s_%s-%s.%d_amd64.deb",
 				baseURL,
@@ -176,12 +177,12 @@ func fetchUbuntuGenericKernelURL(baseURL string, kr kernelrelease.KernelRelease,
 				firstExtra,
 				kernelVersion,
 			),
-		}
-	} else {
-		return []string{
+			// For 5.4 GKE kernels
 			fmt.Sprintf(
-				"%s/linux-headers-%s-%s_%s-%s.%d_all.deb",
+				"%s/linux-gke-%s.%s-headers-%s-%s_%s-%s.%d~18.04.1_amd64.deb",
 				baseURL,
+				kr.Version,
+				kr.PatchLevel,
 				kr.Fullversion,
 				firstExtra,
 				kr.Fullversion,
@@ -189,7 +190,7 @@ func fetchUbuntuGenericKernelURL(baseURL string, kr kernelrelease.KernelRelease,
 				kernelVersion,
 			),
 			fmt.Sprintf(
-				"%s/linux-headers-%s%s_%s-%s.%d_amd64.deb",
+				"%s/linux-headers-%s%s_%s-%s.%d~18.04.1_amd64.deb",
 				baseURL,
 				kr.Fullversion,
 				kr.FullExtraversion,
@@ -198,6 +199,27 @@ func fetchUbuntuGenericKernelURL(baseURL string, kr kernelrelease.KernelRelease,
 				kernelVersion,
 			),
 		}
+	}
+
+	return []string{
+		fmt.Sprintf(
+			"%s/linux-headers-%s-%s_%s-%s.%d_all.deb",
+			baseURL,
+			kr.Fullversion,
+			firstExtra,
+			kr.Fullversion,
+			firstExtra,
+			kernelVersion,
+		),
+		fmt.Sprintf(
+			"%s/linux-headers-%s%s_%s-%s.%d_amd64.deb",
+			baseURL,
+			kr.Fullversion,
+			kr.FullExtraversion,
+			kr.Fullversion,
+			firstExtra,
+			kernelVersion,
+		),
 	}
 }
 


### PR DESCRIPTION


Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>



**What type of PR is this?**



/kind feature



**Any specific area of the project related to this PR?**


/area pkg



**What this PR does / why we need it**:

This PR adds to the `ubuntu-generic` builder the ability to find GKE 5.4 kernels too.

The URLs are very similar to the GKE 4.15 kernels except for a part in the end that contains the `~18.04.1` string. For this reason, since this string can change in the future, I preferred to explicitly list this other URL structure rather than using regexp or something like that.

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

To test it use a YAML like this:

```yaml
kernelversion: 37
kernelrelease: 5.4.0-1035-gke
target: ubuntu-generic
output:
  module: /tmp/falco_ubuntu-generic_5.4.0-1035-gke_37.ko
  probe: /tmp/falco_ubuntu-generic_5.4.0-1035-gke_37.o
```

**Does this PR introduce a user-facing change?**:


```release-note
new: ubuntu-generic builder support GKE 5.4 kernels too
```
