### PR TITLE
Docker network and dns flag support

### DIFF
--- a/cmd/docker.go
+++ b/cmd/docker.go
@@ -11,13 +11,19 @@ import (
 
 // NewDockerCmd creates the `driverkit docker` command.
 func NewDockerCmd(rootOpts *RootOptions, rootFlags *pflag.FlagSet) *cobra.Command {
+	dockerOptions = NewDockerOptions()
 	dockerCmd := &cobra.Command{
 		Use:   "docker",
 		Short: "Build Falco kernel modules and eBPF probes against a docker daemon.",
 		Run: func(c *cobra.Command, args []string) {
 			logrus.WithField("processor", c.Name()).Info("driver building, it will take a few seconds")
+			if errs := dockerOptions.Validate(); errs != nil {
+				for _, err := range errs {
+					logger.WithError(err).Fatal("error validating docker options")
+				}
+			}
 			if !configOptions.DryRun {
-				if err := driverbuilder.NewDockerBuildProcessor(viper.GetInt("timeout"), viper.GetString("proxy")).Start(rootOpts.toBuild()); err != nil {
+				if err := driverbuilder.NewDockerBuildProcessor(viper.GetInt("timeout"), viper.GetString("proxy"), dockerOptions.DNS, dockerOptions.NetworkMode).Start(rootOpts.toBuild()); err != nil {
 					logger.WithError(err).Fatal("exiting")
 				}
 			}
@@ -25,6 +31,12 @@ func NewDockerCmd(rootOpts *RootOptions, rootFlags *pflag.FlagSet) *cobra.Comman
 	}
 	// Add root flags
 	dockerCmd.PersistentFlags().AddFlagSet(rootFlags)
+
+	 // Add command flags
+	flags := dockerCmd.Flags()
+	flags.StringSliceVar(&dockerOptions.DNS, "dns", dockerOptions.DNS, "Set custom DNS servers")
+	flags.StringVar(&dockerOptions.NetworkMode, "network", dockerOptions.NetworkMode, "Connect a container to a network")
+	viper.BindPFlags(flags)
 
 	return dockerCmd
 }

--- a/cmd/docker_options.go
+++ b/cmd/docker_options.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+      "fmt"
+
+      "github.com/creasty/defaults"
+      "github.com/falcosecurity/driverkit/validate"
+      "github.com/go-playground/validator/v10"
+      logger "github.com/sirupsen/logrus"
+)
+
+var dockerOptions *DockerOptions
+
+// DockerOptions represent the configuration flags for the driverkit docker subcommand.
+type DockerOptions struct {
+      DNS          []string `validate:"gte=0,dive,ip" name:"docker dns" default:[]string{}`
+      NetworkMode  string   `validate:"omitempty" name:"docker network"`
+
+      configErrors bool
+}
+
+// NewDockerOptions creates an instance of DockerOptions.
+func NewDockerOptions() *DockerOptions {
+      o := &DockerOptions{}
+      if err := defaults.Set(o); err != nil {
+            logger.WithError(err).WithField("options", "DockerOptions").Fatal("error setting driverkit docker option defaults")
+      }
+      return o
+}
+
+// Validate validates the DockerOptions fields.
+func (do *DockerOptions) Validate() []error {
+      if err := validate.V.Struct(do); err != nil {
+            errors := err.(validator.ValidationErrors)
+            errArr := []error{}
+            for _, e := range errors {
+                  // Translate each error one at a time
+                  errArr = append(errArr, fmt.Errorf(e.Translate(validate.T)))
+            }
+            do.configErrors = true
+            return errArr
+      }
+      return nil
+}

--- a/pkg/driverbuilder/docker.go
+++ b/pkg/driverbuilder/docker.go
@@ -29,16 +29,20 @@ import (
 const DockerBuildProcessorName = "docker"
 
 type DockerBuildProcessor struct {
-	clean   bool
-	timeout int
-	proxy   string
+	clean       bool
+	timeout     int
+	proxy       string
+    dns         []string
+    networkMode string
 }
 
 // NewDockerBuildProcessor ...
-func NewDockerBuildProcessor(timeout int, proxy string) *DockerBuildProcessor {
+func NewDockerBuildProcessor(timeout int, proxy string, dns []string, networkMode string) *DockerBuildProcessor {
 	return &DockerBuildProcessor{
-		timeout: timeout,
-		proxy:   proxy,
+		timeout:     timeout,
+		proxy:       proxy,
+        dns:         dns,
+        networkMode: networkMode,
 	}
 }
 
@@ -115,7 +119,9 @@ func (bp *DockerBuildProcessor) Start(b *builder.Build) error {
 	}
 
 	hostCfg := &container.HostConfig{
-		AutoRemove: true,
+		AutoRemove:  true,
+        DNS:         bp.dns,
+        NetworkMode: container.NetworkMode(bp.networkMode),
 	}
 	networkCfg := &network.NetworkingConfig{}
 	uid := uuid.NewUUID()


### PR DESCRIPTION
Adds NetworkMode and DNS config for docker containers started by driverkit.


**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area build

/area cmd

**What this PR does / why we need it**:

Adds new flags to the driverkit docker command to enable docker --network and --dns to be set for the build time container that is run to create the given driver/probe. For systems with docker not in host/bridge mode there is no way for the build container to reach out and curl the needed dependencies, with the addition of --network and --dns flags this config can be passed to the docker run api in order to setup the NetworkMode and enable the container to successful run and build the driver/probe.

**Special notes for your reviewer**:

Tested manually, when looking into the docker subcommand test setup there are changes needed in order to support error reporting and moving the use of Fatal from within the subcommand to report success/failure differently than it does today. This refactor will result in larger changes to the given root/k8s/docker commands and was excluded and is out of scope in this specific PR and is better suited for a focused PR around testing the subcommands better. 

**Does this PR introduce a user-facing change?**:

Adds new flags to the docker subcommand that are optional, will not break existing functionality.

```release-note

```
