### PR TITLE
fix(pkg/driverbuilder): include KBUILD_MODNAME in driver_config.h for BPF targets

### DIFF
--- a/pkg/driverbuilder/templates.go
+++ b/pkg/driverbuilder/templates.go
@@ -82,6 +82,10 @@ const driverConfigTemplate = `
 #define PROBE_NAME "{{ .DriverName }}"
 
 #define PROBE_DEVICE_NAME "{{ .DeviceName }}"
+
+#ifndef KBUILD_MODNAME
+#define KBUILD_MODNAME PROBE_NAME
+#endif
 `
 
 func renderDriverConfig(w io.Writer, dd driverConfigData) error {


### PR DESCRIPTION
When we build the BPF probe, we put ourselves in the kernel context
as if we were a kernel module with the `M=` option.

Doing so requires KBUILD_MODNAME to be defined in newer kernels.


This was already added by @nathan-b in libs here https://github.com/falcosecurity/libs/blob/master/driver/driver_config.h.in


Signed-off-by: Lorenzo Fontana <lo@linux.com>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**


**What this PR does / why we need it**:

Our [test-infra logs are](https://falco-prow-logs.s3.eu-west-1.amazonaws.com/logs/build-drivers-ubuntu-generic-periodic/1373107107963867136/build-log.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAUIOA5MU2BCUB3HES%2F20210325%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20210325T112632Z&X-Amz-Expires=600&X-Amz-Security-Token=FwoGZXIvYXdzEMX%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaDPg%2FaO%2BULU4V7wxd6SKFBJlmy%2BqJoAMYPGrScr1nI6rW4jt1bV9jtO%2Bh4DnwUGhn6tx92ObJyTdI2bNLI2V4EpDEN68YWSljYZjA0rDFC6XUlxRQhYZYAkcwaVY9FLhrNYDozaz3bMaT7JWbOMOkIm1j%2B4SKQYpqTM5%2BRAmmkbuoeRiSL5QI6Us9by65GxcmfhIQ4XklsPGWv57LmzS308GvR9NqhoqRPiru%2BTy63OOUqUsQf7R0hYZoL1HW5jfxBphSmBmdVA76KPoOYlZVCSJmG601MGTGcZu4aAdijeEEwQf8WlDocnEbwJjfPIKHQFma8TDjiMMYjLIAfajEfGdgF8TFW7H7UzBwytIk8EzYfS4LcES597lKAhqZcTAj22PClIgFIkNpRG%2ByuYfbnY5LI9Lo4D10w%2Fh3GWjqkZrwUPCpZPRAsGA%2FQB%2BEibiHPwP4kZxjx%2FzI5jV8U3OFJg5vLf7XaR4oL2XI2rHto4emZxMA08sI%2FESiu%2FTaemxev9G9E4EXLLkLfGwgeGBVV2iSvO5rfEF%2Bu%2FWsfJvONHN5YQKWDyPIqQIhr%2F1kBYdPSw9rDo6OhMbyQXs%2Fg6YW6%2FeciA8iwTvbwRgedc5yQxM%2BCSj6zeM6t1CzHpK1UavqLtuSmXyiVMXlYs6okwDrNffwDtQRAyfn6dMnn%2FjOeYT7BqlROLr7SGlrCiO7UJdhyj9ktgoo2N7xggYyKp0SiiBbg8oQqi1aqV5OmFqiWKQoSkErHhJbJmX270%2BJQN39uuNsP%2FD7pQ%3D%3D&X-Amz-SignedHeaders=host&X-Amz-Signature=311bc60c6efd277f2c17ac919a7332775a60b64c26379af22e1064c9a4bad353) showing that for many kernels BPF probes can not build.


Relevant log line

```
[36mINFO[0m kernel module available                       [36mpath[0m=output/2aa88dcf6243982697811df4c1b484bcbe9488a2/falco_ubuntu-generic_5.8.0-40-generic_45.ko
[31mFATA[0m exiting                                       [31merror[0m="Error: No such container:path: bc099659b9b4a0621958b2f3c6dd4c13ed2513a7becd7837ecf0417e9535e710:/tmp/driver/bpf/probe.o"
```



**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
fix: BPF probe builds for Kernels requiring KBUILD_MODNAME
```
