### PR TITLE
docs(readme.md): update ebpf probe default path

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ How does this work?
 If the user specifies:
 
 - `c.Build.ModuleFilePath` you will need to build the kernel module and save it in /tmp/driver/falco.ko`
-- `c.Build.ProbeFilePath` you will need to build the eBPF probe and save it in /tmp/driver/probe.ko`
+- `c.Build.ProbeFilePath` you will need to build the eBPF probe and save it in /tmp/driver/probe.o`
 
 The `/tmp/driver` MUST be interpolated from the `DriverDirectory` constant from [`builders.go`](/pkg/driverbuilder/builder/builders.go).
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**Any specific area of the project related to this PR?**

/area docs

**What this PR does / why we need it**:

This PR updates the `README.md` according to the `builder`-expected default eBPF probe filepath.

**Special notes for your reviewer**:

The `README.md` currently indicates a wrong expected path for the built probe (`/tmp/driver/probe.ko` instead of `/tmp/driver/probe.o`).

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
