### PR TITLE
Add CentOS 8 Vault RPMs to centos driverbuilder

### DIFF
--- a/pkg/driverbuilder/builder/centos.go
+++ b/pkg/driverbuilder/builder/centos.go
@@ -98,6 +98,13 @@ func fetchCentosKernelURLS(kr kernelrelease.KernelRelease) []string {
 		"8.1.1911/updates",
 	}
 
+	centos8VaultReleases := []string{
+		"8.0.1905/BaseOS",
+		"8.1.1911/BaseOS",
+		"8.2.2004/BaseOS",
+		"8.3.2011/BaseOS",
+	}
+
 	edgeReleases := []string{
 		"6/os",
 		"6/updates",
@@ -108,8 +115,6 @@ func fetchCentosKernelURLS(kr kernelrelease.KernelRelease) []string {
 	streamReleases := []string{
 		"8/BaseOS",
 		"8-stream/BaseOS",
-		"8.0.1905/BaseOS",
-		"8.1.1911/BaseOS",
 	}
 
 	urls := []string{}
@@ -132,6 +137,14 @@ func fetchCentosKernelURLS(kr kernelrelease.KernelRelease) []string {
 	for _, r := range vaultReleases {
 		urls = append(urls, fmt.Sprintf(
 			"http://vault.centos.org/%s/x86_64/Packages/kernel-devel-%s%s.rpm",
+			r,
+			kr.Fullversion,
+			kr.FullExtraversion,
+		))
+	}
+	for _, r := range centos8VaultReleases {
+		urls = append(urls, fmt.Sprintf(
+			"http://vault.centos.org/%s/x86_64/os/Packages/kernel-devel-%s%s.rpm",
 			r,
 			kr.Fullversion,
 			kr.FullExtraversion,


### PR DESCRIPTION
Signed-off-by: David Windsor <dwindsor@secureworks.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

**What this PR does / why we need it**:

Some CentOS releases have been moved from Stream to Vault since the centos driverbuilder was created. This causes test-infra tests to fail when building CentOS 8.3, 8.2, and 8.1 kernels (8.4 kernels build successfully in test-infra):

```
utils/checkfiles config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-240.10.1.el8_3.x86_64_1.yaml
[36mINFO[0m using config file                             [36mfile[0m=config/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/centos_4.18.0-240.10.1.el8_3.x86_64_1.yaml
[36mINFO[0m driver building, it will take a few seconds   [36mprocessor[0m=docker
[31mFATA[0m exiting                                       [31merror[0m="kernel not found"
```

For some reason, CentOS 8 releasees follow a different directory structure on `vault.centos.org` than any of the previous CentOS releases so special-case handling needs to be added to download these RPMs.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #105 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
