### PR TITLE
build(builder): pin base image version to `debian:buster`

### DIFF
--- a/build/builder.Dockerfile
+++ b/build/builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable
+FROM debian:buster
 
 LABEL maintainer="cncf-falco-dev@lists.cncf.io"
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area build


**What this PR does / why we need it**:

Currently, the publishing of the builder image is broken (see the [failing test](https://app.circleci.com/pipelines/github/falcosecurity/driverkit/152/workflows/c51b0e45-0adc-4965-8f8d-c68f03894df2/jobs/215) on the master branch).

So, this PR introduces a simple workaround to make the builder image work again.
The root issue is due to `debian:stable` which recently moved forward and removed clang7. So we just pin the last working version, which is `debian:buster`. We already did the same thing on Falco, see https://github.com/falcosecurity/falco/pull/1719.


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

Upgrading to a newer clang version is out-of-scope for this PR. The intent is just to make the tool work again shortly.

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
