### PR TITLE
fix(build): use llvm/clang 12 to build the probe on Linux Kernel 5.x on Debian

### DIFF
--- a/build/builder.Dockerfile
+++ b/build/builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable
+FROM debian:buster
 
 LABEL maintainer="cncf-falco-dev@lists.cncf.io"
 
@@ -31,7 +31,17 @@ RUN apt-get update \
 	libudev-dev \
 	libpci-dev \
 	libiberty-dev \
+    lsb-release \
+    wget \
+    software-properties-common \
+    gpg \
 	&& rm -rf /var/lib/apt/lists/*
+
+# Install clang 12
+RUN cd /tmp \
+    && wget https://apt.llvm.org/llvm.sh \
+    && chmod +x llvm.sh \
+    && ./llvm.sh 12
 
 # gcc 6 is no longer included in debian stable, but we need it to
 # build kernel modules on the default debian-based ami used by

--- a/build/builder.Dockerfile
+++ b/build/builder.Dockerfile
@@ -31,17 +31,17 @@ RUN apt-get update \
 	libudev-dev \
 	libpci-dev \
 	libiberty-dev \
-    lsb-release \
-    wget \
-    software-properties-common \
-    gpg \
+	lsb-release \
+	wget \
+	software-properties-common \
+	gpg \
 	&& rm -rf /var/lib/apt/lists/*
 
 # Install clang 12
 RUN cd /tmp \
-    && wget https://apt.llvm.org/llvm.sh \
-    && chmod +x llvm.sh \
-    && ./llvm.sh 12
+	&& wget https://apt.llvm.org/llvm.sh \
+	&& chmod +x llvm.sh \
+	&& ./llvm.sh 12
 
 # gcc 6 is no longer included in debian stable, but we need it to
 # build kernel modules on the default debian-based ami used by


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area cmd

> /area pkg

> /area docs

> /area tests

**What this PR does / why we need it**:

Since Falco's eBPF probe supports clang 12 we can use it in the builder image. It appears that debian kernel 5.10 won't compile properly with clang 7, but works fine with 11+. See issue #106 for additional information.

PS: this PR contains the `buster` change from #110 , if this is accepted the other is superseded.

**Which issue(s) this PR fixes**:

https://github.com/falcosecurity/driverkit/issues/106

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note

```
