### PR TITLE
driverkit: Move CentOS 8.4 to Vault

### DIFF
--- a/pkg/driverbuilder/builder/centos.go
+++ b/pkg/driverbuilder/builder/centos.go
@@ -105,6 +105,7 @@ func fetchCentosKernelURLS(kr kernelrelease.KernelRelease) []string {
 		"8.1.1911/BaseOS",
 		"8.2.2004/BaseOS",
 		"8.3.2011/BaseOS",
+		"8.4.2105/BaseOS",
 	}
 
 	edgeReleases := []string{


### PR DESCRIPTION
Signed-off-by: David Windsor <dwindsor@secureworks.com>

CentOS 8.5 was released on 2021-11-16. Since then, CentOS 8.4 has been reclassified as a Vault release; its RPMs are no longer hosted on mirrors.edge.kernel.org.

Fix pkg/driverbuilder/builder/centos.go so it looks for CentOS 8.4 RPMs on vault.centos.org rather than mirrors.edge.kernel.org (which now hosts CentOS 8.5 RPMs).

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #114 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note

```
