### PR TITLE
new(build): add CentOS 7.9 and 8.5

### DIFF
--- a/pkg/driverbuilder/builder/centos.go
+++ b/pkg/driverbuilder/builder/centos.go
@@ -96,6 +96,8 @@ func fetchCentosKernelURLS(kr kernelrelease.KernelRelease) []string {
 		"7.7.1908/updates",
 		"7.8.2003/os",
 		"7.8.2003/updates",
+		"7.9.2009/os",
+		"7.9.2009/updates",
 		"8.0.1905/os",
 		"8.0.1905/updates",
 		"8.1.1911/os",
@@ -108,6 +110,7 @@ func fetchCentosKernelURLS(kr kernelrelease.KernelRelease) []string {
 		"8.2.2004/BaseOS",
 		"8.3.2011/BaseOS",
 		"8.4.2105/BaseOS",
+		"8.5.2111/BaseOS",
 	}
 
 	edgeReleases := []string{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area cmd

> /area pkg

> /area docs

> /area tests


**What this PR does / why we need it**:

This simply adds the necessary versions for CentOS 7.9 and 8.5 as found in the official repos.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

Do we already need to add this or do we need to do that only if they're not the latest releases?

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
new(build): add support for CentOS 7.9 and 8.5
```
