### PR TITLE
add --dockerimage argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ IMAGE_NAME_DRIVERKIT_REF := $(IMAGE_NAME_DRIVERKIT):$(GIT_REF)
 IMAGE_NAME_DRIVERKIT_COMMIT := $(IMAGE_NAME_DRIVERKIT):$(GIT_COMMIT)
 IMAGE_NAME_DRIVERKIT_LATEST := $(IMAGE_NAME_DRIVERKIT):latest
 
-LDFLAGS := -X github.com/falcosecurity/driverkit/pkg/version.buildTime=$(shell date +%s) -X github.com/falcosecurity/driverkit/pkg/version.gitCommit=${GIT_COMMIT} -X github.com/falcosecurity/driverkit/pkg/version.gitTag=$(if ${GIT_TAG},${GIT_TAG},v0.0.0) -X github.com/falcosecurity/driverkit/pkg/version.commitsFromGitTag=${COMMITS_FROM_GIT_TAG} -X github.com/falcosecurity/driverkit/pkg/driverbuilder.builderBaseImage=${IMAGE_NAME_BUILDER_COMMIT}
+LDFLAGS := -X github.com/falcosecurity/driverkit/pkg/version.buildTime=$(shell date +%s) -X github.com/falcosecurity/driverkit/pkg/version.gitCommit=${GIT_COMMIT} -X github.com/falcosecurity/driverkit/pkg/version.gitTag=$(if ${GIT_TAG},${GIT_TAG},v0.0.0) -X github.com/falcosecurity/driverkit/pkg/version.commitsFromGitTag=${COMMITS_FROM_GIT_TAG} -X github.com/falcosecurity/driverkit/pkg/driverbuilder.BuilderDefaultImage=${IMAGE_NAME_BUILDER_COMMIT}
 
 OS_NAME := $(shell uname -s | tr A-Z a-z)
 SQLITE_TAGS :=

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -61,10 +61,8 @@ func NewCompletionCmd() *cobra.Command {
 			switch arg {
 			case "bash":
 				c.Root().GenBashCompletion(os.Stdout)
-				break
 			case "zsh":
 				c.Root().GenZshCompletion(os.Stdout)
-				break
 			case "fish":
 				c.Root().GenFishCompletion(os.Stdout, true)
 			case "help":

--- a/cmd/docker.go
+++ b/cmd/docker.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"github.com/falcosecurity/driverkit/pkg/driverbuilder"
-	"github.com/sirupsen/logrus"
 	logger "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -15,9 +14,9 @@ func NewDockerCmd(rootOpts *RootOptions, rootFlags *pflag.FlagSet) *cobra.Comman
 		Use:   "docker",
 		Short: "Build Falco kernel modules and eBPF probes against a docker daemon.",
 		Run: func(c *cobra.Command, args []string) {
-			logrus.WithField("processor", c.Name()).Info("driver building, it will take a few seconds")
+			logger.WithField("processor", c.Name()).Info("driver building, it will take a few seconds")
 			if !configOptions.DryRun {
-				if err := driverbuilder.NewDockerBuildProcessor(viper.GetInt("timeout"), viper.GetString("proxy")).Start(rootOpts.toBuild()); err != nil {
+				if err := driverbuilder.NewDockerBuildProcessor(viper.GetInt("timeout"), viper.GetString("proxy"), rootOpts.DockerImage).Start(rootOpts.toBuild()); err != nil {
 					logger.WithError(err).Fatal("exiting")
 				}
 			}

--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/falcosecurity/driverkit/pkg/driverbuilder"
 	"github.com/falcosecurity/driverkit/pkg/kubernetes/factory"
-	"github.com/sirupsen/logrus"
 	logger "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -41,7 +40,7 @@ func NewKubernetesCmd(rootOpts *RootOptions, rootFlags *pflag.FlagSet) *cobra.Co
 	kubefactory := factory.NewFactory(configFlags)
 
 	kubernetesCmd.Run = func(cmd *cobra.Command, args []string) {
-		logrus.WithField("processor", cmd.Name()).Info("driver building, it will take a few seconds")
+		logger.WithField("processor", cmd.Name()).Info("driver building, it will take a few seconds")
 		if !configOptions.DryRun {
 			if err := kubernetesRun(cmd, args, kubefactory, rootOpts); err != nil {
 				logger.WithError(err).Fatal("exiting")
@@ -76,7 +75,7 @@ func kubernetesRun(cmd *cobra.Command, args []string, kubefactory factory.Factor
 		return err
 	}
 
-	buildProcessor := driverbuilder.NewKubernetesBuildProcessor(kc.CoreV1(), clientConfig, namespaceStr, viper.GetInt("timeout"), viper.GetString("proxy"))
+	buildProcessor := driverbuilder.NewKubernetesBuildProcessor(kc.CoreV1(), clientConfig, namespaceStr, viper.GetInt("timeout"), viper.GetString("proxy"), rootOpts.DockerImage)
 
 	return buildProcessor.Start(b)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/falcosecurity/driverkit/pkg/driverbuilder"
 	"github.com/falcosecurity/driverkit/pkg/driverbuilder/builder"
 	"github.com/falcosecurity/driverkit/pkg/version"
 	"github.com/spf13/cobra"
@@ -113,6 +114,7 @@ func NewRootCmd() *RootCmd {
 	flags.StringVar(&rootOpts.DriverVersion, "driverversion", rootOpts.DriverVersion, "driver version as a git commit hash or as a git tag")
 	flags.Uint16Var(&rootOpts.KernelVersion, "kernelversion", rootOpts.KernelVersion, "kernel version to build the module for, it's the numeric value after the hash when you execute 'uname -v'")
 	flags.StringVar(&rootOpts.KernelRelease, "kernelrelease", rootOpts.KernelRelease, "kernel release to build the module for, it can be found by executing 'uname -v'")
+	flags.StringVar(&rootOpts.DockerImage, "dockerimage", driverbuilder.BuilderDefaultImage, "docker image to use for build")
 	flags.StringVarP(&rootOpts.Target, "target", "t", rootOpts.Target, "the system to target the build for")
 	flags.StringVar(&rootOpts.KernelConfigData, "kernelconfigdata", rootOpts.KernelConfigData, "base64 encoded kernel config data: in some systems it can be found under the /boot directory, in other it is gzip compressed under /proc")
 	flags.StringVar(&rootOpts.ModuleDeviceName, "moduledevicename", rootOpts.ModuleDeviceName, "kernel module device name (the default is falco, so the device will be under /dev/falco*)")

--- a/cmd/root_options.go
+++ b/cmd/root_options.go
@@ -23,6 +23,7 @@ type RootOptions struct {
 	KernelVersion    uint16 `default:"1" validate:"omitempty,number" name:"kernel version"`
 	ModuleDriverName string `default:"falco" validate:"max=60" name:"kernel module driver name"`
 	ModuleDeviceName string `default:"falco" validate:"excludes=/,max=255" name:"kernel module device name"`
+	DockerImage      string `name:"docker image"`
 	KernelRelease    string `validate:"required,ascii" name:"kernel release"`
 	Target           string `validate:"required,target" name:"target"`
 	KernelConfigData string `validate:"omitempty,base64" name:"kernel config data"` // fixme > tag "name" does not seem to work when used at struct level, but works when used at inner level

--- a/cmd/testdata/autohelp.txt
+++ b/cmd/testdata/autohelp.txt
@@ -13,6 +13,7 @@ Available Commands:
 
 Flags:
   -c, --config string             config file path (default $HOME/.driverkit.yaml if exists)
+      --dockerimage string        docker image to use for build (default "falcosecurity/driverkit-builder:latest")
       --driverversion string      driver version as a git commit hash or as a git tag (default "dev")
       --dryrun                    do not actually perform the action
   -h, --help                      help for driverkit

--- a/cmd/testdata/dockernoopts.txt
+++ b/cmd/testdata/dockernoopts.txt
@@ -8,6 +8,7 @@ Usage:
 
 Flags:
   -c, --config string             config file path (default $HOME/.driverkit.yaml if exists)
+      --dockerimage string        docker image to use for build (default "falcosecurity/driverkit-builder:latest")
       --driverversion string      driver version as a git commit hash or as a git tag (default "dev")
       --dryrun                    do not actually perform the action
   -h, --help                      help for docker

--- a/cmd/testdata/help-flag.txt
+++ b/cmd/testdata/help-flag.txt
@@ -12,6 +12,7 @@ Available Commands:
 
 Flags:
   -c, --config string             config file path (default $HOME/.driverkit.yaml if exists)
+      --dockerimage string        docker image to use for build (default "falcosecurity/driverkit-builder:latest")
       --driverversion string      driver version as a git commit hash or as a git tag (default "dev")
       --dryrun                    do not actually perform the action
   -h, --help                      help for driverkit

--- a/cmd/testdata/help.txt
+++ b/cmd/testdata/help.txt
@@ -12,6 +12,7 @@ Available Commands:
 
 Flags:
   -c, --config string             config file path (default $HOME/.driverkit.yaml if exists)
+      --dockerimage string        docker image to use for build (default "falcosecurity/driverkit-builder:latest")
       --driverversion string      driver version as a git commit hash or as a git tag (default "dev")
       --dryrun                    do not actually perform the action
   -h, --help                      help for driverkit

--- a/cmd/testdata/invalid-proxyconfig.txt
+++ b/cmd/testdata/invalid-proxyconfig.txt
@@ -12,6 +12,7 @@ Available Commands:
 
 Flags:
   -c, --config string             config file path (default $HOME/.driverkit.yaml if exists)
+      --dockerimage string        docker image to use for build (default "falcosecurity/driverkit-builder:latest")
       --driverversion string      driver version as a git commit hash or as a git tag (default "dev")
       --dryrun                    do not actually perform the action
   -h, --help                      help for driverkit

--- a/cmd/testdata/non-existent-processor.txt
+++ b/cmd/testdata/non-existent-processor.txt
@@ -11,6 +11,7 @@ Available Commands:
 
 Flags:
   -c, --config string             config file path (default $HOME/.driverkit.yaml if exists)
+      --dockerimage string        docker image to use for build (default "falcosecurity/driverkit-builder:latest")
       --driverversion string      driver version as a git commit hash or as a git tag (default "dev")
       --dryrun                    do not actually perform the action
   -h, --help                      help for driverkit

--- a/pkg/driverbuilder/builder/builders.go
+++ b/pkg/driverbuilder/builder/builders.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"path"
 
-	"github.com/sirupsen/logrus"
+	logger "github.com/sirupsen/logrus"
 )
 
 // DriverDirectory is the directory the processor uses to store the driver.
@@ -58,7 +58,7 @@ func getResolvingURLs(urls []string) ([]string, error) {
 		}
 		if res.StatusCode == http.StatusOK {
 			results = append(results, u)
-			logrus.WithField("url", u).Debug("kernel header url found")
+			logger.WithField("url", u).Debug("kernel header url found")
 		}
 	}
 	if len(results) == 0 {

--- a/pkg/driverbuilder/buildprocessor.go
+++ b/pkg/driverbuilder/buildprocessor.go
@@ -8,7 +8,7 @@ type BuildArchitecture string
 
 const BuildArchitectureX86_64 BuildArchitecture = "x86_64"
 
-var builderBaseImage = "falcosecurity/driverkit-builder:latest" // This is overwritten when using the Makefile to build
+var BuilderDefaultImage = "falcosecurity/driverkit-builder:latest" // This is overwritten when using the Makefile to build
 
 func (ba BuildArchitecture) String() string {
 	return string(ba)

--- a/pkg/driverbuilder/kubernetes.go
+++ b/pkg/driverbuilder/kubernetes.go
@@ -34,19 +34,21 @@ type KubernetesBuildProcessor struct {
 	namespace    string
 	timeout      int
 	proxy        string
+	image        string
 }
 
 // NewKubernetesBuildProcessor constructs a KubernetesBuildProcessor
 // starting from a kubernetes.Clientset. bufferSize represents the length of the
 // channel we use to do the builds. A bigger bufferSize will mean that we can save more Builds
 // for processing, however setting this to a big value will have impacts
-func NewKubernetesBuildProcessor(corev1Client v1.CoreV1Interface, clientConfig *restclient.Config, namespace string, timeout int, proxy string) *KubernetesBuildProcessor {
+func NewKubernetesBuildProcessor(corev1Client v1.CoreV1Interface, clientConfig *restclient.Config, namespace string, timeout int, proxy, image string) *KubernetesBuildProcessor {
 	return &KubernetesBuildProcessor{
 		coreV1Client: corev1Client,
 		clientConfig: clientConfig,
 		namespace:    namespace,
 		timeout:      timeout,
 		proxy:        proxy,
+		image:        image,
 	}
 }
 
@@ -157,7 +159,7 @@ func (bp *KubernetesBuildProcessor) buildModule(build *builder.Build) error {
 			Containers: []corev1.Container{
 				{
 					Name:            name,
-					Image:           builderBaseImage,
+					Image:           bp.image,
 					Command:         buildCmd,
 					Env:             envs,
 					ImagePullPolicy: corev1.PullIfNotPresent,


### PR DESCRIPTION
Signed-off-by: Issif <issif+github@gadz.org>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area cmd

/area pkg

> /area docs

> /area tests


**What this PR does / why we need it**:

This commands allows to set `--dockerimage` as argument. This allows to test different versions for `builder` image without having to recompile `driverkit`. The default value remains same than before, 

```makefile
IMAGE_NAME_BUILDER ?= docker.io/falcosecurity/driverkit-builder
IMAGE_NAME_BUILDER_COMMIT := $(IMAGE_NAME_BUILDER):$(GIT_COMMIT)

LDFLAGS := ... -X github.com/falcosecurity/driverkit/pkg/driverbuilder.BuilderDefaultImage=${IMAGE_NAME_BUILDER_COMMIT}
``` 

```shell
      --dockerimage string        docker image to use for build (default "docker.io/falcosecurity/driverkit-builder:dbc8276.dirty")
```

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

Yes. A new argument is available for CLI, but behavior remains same without.
