### PR TITLE
update(cmd): default value for `--driverversion` is now `master`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ uname -r
 ### Against a Kubernetes cluster
 
 ```bash
-driverkit kubernetes --output-module /tmp/falco.ko --kernelversion=81 --kernelrelease=4.15.0-72-generic --driverversion=dev --target=ubuntu-generic
+driverkit kubernetes --output-module /tmp/falco.ko --kernelversion=81 --kernelrelease=4.15.0-72-generic --driverversion=master --target=ubuntu-generic
 ```
 
 ### Against a Docker daemon
 
 ```bash
-driverkit docker --output-module /tmp/falco.ko --kernelversion=81 --kernelrelease=4.15.0-72-generic --driverversion=dev --target=ubuntu-generic
+driverkit docker --output-module /tmp/falco.ko --kernelversion=81 --kernelrelease=4.15.0-72-generic --driverversion=master --target=ubuntu-generic
 ```
 
 
@@ -47,7 +47,7 @@ target: ubuntu-aws
 output:
   module: /tmp/falco-ubuntu-aws.ko
   probe: /tmp/falco-ubuntu-aws.o
-driverversion: dev
+driverversion: master
 ```
 
 Now run driverkit using the configuration file:
@@ -73,7 +73,7 @@ target: ubuntu-generic
 output:
   module: /tmp/falco-ubuntu-generic.ko
   probe: /tmp/falco-ubuntu-generic.o
-driverversion: dev
+driverversion: master
 ```
 
 ### ubuntu-aws
@@ -87,7 +87,7 @@ target: ubuntu-aws
 output:
   module: /tmp/falco-ubuntu-aws.ko
   probe: /tmp/falco-ubuntu-aws.o
-driverversion: dev
+driverversion: master
 ```
 
 ### centos 6
@@ -98,7 +98,7 @@ kernelversion: 1
 target: centos
 output:
   module: /tmp/falco-centos6.ko
-driverversion: dev
+driverversion: master
 ```
 
 ### centos 7
@@ -109,7 +109,7 @@ kernelversion: 1
 target: centos
 output:
   module: /tmp/falco-centos7.ko
-driverversion: dev
+driverversion: master
 ```
 
 ### centos 8
@@ -120,7 +120,7 @@ kernelversion: 1
 target: centos
 output:
   module: /tmp/falco-centos8.ko
-driverversion: dev
+driverversion: master
 ```
 
 ### amazonlinux
@@ -155,7 +155,7 @@ output:
   module: /tmp/falco-debian.ko
   probe: /tmp/falco-debian.o
 target: debian
-driverversion: dev
+driverversion: master
 ```
 
 ### vanilla

--- a/cmd/root_options.go
+++ b/cmd/root_options.go
@@ -19,7 +19,7 @@ type OutputOptions struct {
 // RootOptions ...
 type RootOptions struct {
 	Architecture     string `default:"x86_64" validate:"required,oneof=x86_64" name:"architecture"`
-	DriverVersion    string `default:"dev" validate:"eq=dev|sha1|semver" name:"driver version"`
+	DriverVersion    string `default:"master" validate:"eq=master|sha1|semver" name:"driver version"`
 	KernelVersion    uint16 `default:"1" validate:"omitempty,number" name:"kernel version"`
 	ModuleDriverName string `default:"falco" validate:"max=60" name:"kernel module driver name"`
 	ModuleDeviceName string `default:"falco" validate:"excludes=/,max=255" name:"kernel module device name"`

--- a/cmd/testdata/autohelp.txt
+++ b/cmd/testdata/autohelp.txt
@@ -13,7 +13,7 @@ Available Commands:
 
 Flags:
   -c, --config string             config file path (default $HOME/.driverkit.yaml if exists)
-      --driverversion string      driver version as a git commit hash or as a git tag (default "dev")
+      --driverversion string      driver version as a git commit hash or as a git tag (default "master")
       --dryrun                    do not actually perform the action
   -h, --help                      help for driverkit
       --kernelconfigdata string   base64 encoded kernel config data: in some systems it can be found under the /boot directory, in other it is gzip compressed under /proc

--- a/cmd/testdata/configs/1.yaml
+++ b/cmd/testdata/configs/1.yaml
@@ -3,4 +3,4 @@ kernelversion: 59
 target: ubuntu-aws
 output:
     module: /tmp/falco-ubuntu-aws.ko
-driverversion: dev
+driverversion: master

--- a/cmd/testdata/docker-from-config-debug.txt
+++ b/cmd/testdata/docker-from-config-debug.txt
@@ -1,3 +1,3 @@
 INFO using config file                             file=testdata/configs/1.yaml
-DEBU running with options                          driverversion=dev kernelrelease=4.15.0-1057-aws kernelversion=59 output-module=/tmp/falco-ubuntu-aws.ko target=ubuntu-aws
+DEBU running with options                          driverversion=master kernelrelease=4.15.0-1057-aws kernelversion=59 output-module=/tmp/falco-ubuntu-aws.ko target=ubuntu-aws
 INFO driver building, it will take a few seconds   processor=docker

--- a/cmd/testdata/docker-override-from-config-debug.txt
+++ b/cmd/testdata/docker-override-from-config-debug.txt
@@ -1,3 +1,3 @@
 INFO using config file                             file=testdata/configs/1.yaml
-DEBU running with options                          driverversion=dev kernelrelease=4.15.0-1057-aws kernelversion=229 output-module=/tmp/override.ko target=ubuntu-aws
+DEBU running with options                          driverversion=master kernelrelease=4.15.0-1057-aws kernelversion=229 output-module=/tmp/override.ko target=ubuntu-aws
 INFO driver building, it will take a few seconds   processor=docker

--- a/cmd/testdata/docker-with-flags-debug.txt
+++ b/cmd/testdata/docker-with-flags-debug.txt
@@ -1,3 +1,3 @@
 DEBU running without a configuration file         
-DEBU running with options                          driverversion=dev kernelrelease=4.15.0-1057-aws kernelversion=59 output-module=/tmp/falco-ubuntu-aws.ko target=ubuntu-aws
+DEBU running with options                          driverversion=master kernelrelease=4.15.0-1057-aws kernelversion=59 output-module=/tmp/falco-ubuntu-aws.ko target=ubuntu-aws
 INFO driver building, it will take a few seconds   processor=docker

--- a/cmd/testdata/dockernoopts.txt
+++ b/cmd/testdata/dockernoopts.txt
@@ -8,7 +8,7 @@ Usage:
 
 Flags:
   -c, --config string             config file path (default $HOME/.driverkit.yaml if exists)
-      --driverversion string      driver version as a git commit hash or as a git tag (default "dev")
+      --driverversion string      driver version as a git commit hash or as a git tag (default "master")
       --dryrun                    do not actually perform the action
   -h, --help                      help for docker
       --kernelconfigdata string   base64 encoded kernel config data: in some systems it can be found under the /boot directory, in other it is gzip compressed under /proc

--- a/cmd/testdata/help-flag.txt
+++ b/cmd/testdata/help-flag.txt
@@ -12,7 +12,7 @@ Available Commands:
 
 Flags:
   -c, --config string             config file path (default $HOME/.driverkit.yaml if exists)
-      --driverversion string      driver version as a git commit hash or as a git tag (default "dev")
+      --driverversion string      driver version as a git commit hash or as a git tag (default "master")
       --dryrun                    do not actually perform the action
   -h, --help                      help for driverkit
       --kernelconfigdata string   base64 encoded kernel config data: in some systems it can be found under the /boot directory, in other it is gzip compressed under /proc

--- a/cmd/testdata/help.txt
+++ b/cmd/testdata/help.txt
@@ -12,7 +12,7 @@ Available Commands:
 
 Flags:
   -c, --config string             config file path (default $HOME/.driverkit.yaml if exists)
-      --driverversion string      driver version as a git commit hash or as a git tag (default "dev")
+      --driverversion string      driver version as a git commit hash or as a git tag (default "master")
       --dryrun                    do not actually perform the action
   -h, --help                      help for driverkit
       --kernelconfigdata string   base64 encoded kernel config data: in some systems it can be found under the /boot directory, in other it is gzip compressed under /proc

--- a/cmd/testdata/invalid-proxyconfig.txt
+++ b/cmd/testdata/invalid-proxyconfig.txt
@@ -12,7 +12,7 @@ Available Commands:
 
 Flags:
   -c, --config string             config file path (default $HOME/.driverkit.yaml if exists)
-      --driverversion string      driver version as a git commit hash or as a git tag (default "dev")
+      --driverversion string      driver version as a git commit hash or as a git tag (default "master")
       --dryrun                    do not actually perform the action
   -h, --help                      help for driverkit
       --kernelconfigdata string   base64 encoded kernel config data: in some systems it can be found under the /boot directory, in other it is gzip compressed under /proc

--- a/cmd/testdata/non-existent-processor.txt
+++ b/cmd/testdata/non-existent-processor.txt
@@ -11,7 +11,7 @@ Available Commands:
 
 Flags:
   -c, --config string             config file path (default $HOME/.driverkit.yaml if exists)
-      --driverversion string      driver version as a git commit hash or as a git tag (default "dev")
+      --driverversion string      driver version as a git commit hash or as a git tag (default "master")
       --dryrun                    do not actually perform the action
   -h, --help                      help for driverkit
       --kernelconfigdata string   base64 encoded kernel config data: in some systems it can be found under the /boot directory, in other it is gzip compressed under /proc

--- a/docs/driverkit.md
+++ b/docs/driverkit.md
@@ -14,15 +14,18 @@ driverkit
 
 ```
   -c, --config string             config file path (default $HOME/.driverkit.yaml if exists)
-      --driverversion string      driver version as a git commit hash or as a git tag (default "dev")
+      --driverversion string      driver version as a git commit hash or as a git tag (default "master")
       --dryrun                    do not actually perform the action
   -h, --help                      help for driverkit
       --kernelconfigdata string   base64 encoded kernel config data: in some systems it can be found under the /boot directory, in other it is gzip compressed under /proc
       --kernelrelease string      kernel release to build the module for, it can be found by executing 'uname -v'
       --kernelversion uint16      kernel version to build the module for, it's the numeric value after the hash when you execute 'uname -v' (default 1)
   -l, --loglevel string           log level (default "info")
+      --moduledevicename string   kernel module device name (the default is falco, so the device will be under /dev/falco*) (default "falco")
+      --moduledrivername string   kernel module driver name, i.e. the name you see when you check installed modules via lsmod (default "falco")
       --output-module string      filepath where to save the resulting kernel module
       --output-probe string       filepath where to save the resulting eBPF probe
+      --proxy string              the proxy to use to download data
   -t, --target string             the system to target the build for
       --timeout int               timeout in seconds (default 60)
 ```

--- a/docs/driverkit_docker.md
+++ b/docs/driverkit_docker.md
@@ -14,15 +14,18 @@ driverkit docker [flags]
 
 ```
   -c, --config string             config file path (default $HOME/.driverkit.yaml if exists)
-      --driverversion string      driver version as a git commit hash or as a git tag (default "dev")
+      --driverversion string      driver version as a git commit hash or as a git tag (default "master")
       --dryrun                    do not actually perform the action
   -h, --help                      help for docker
       --kernelconfigdata string   base64 encoded kernel config data: in some systems it can be found under the /boot directory, in other it is gzip compressed under /proc
       --kernelrelease string      kernel release to build the module for, it can be found by executing 'uname -v'
       --kernelversion uint16      kernel version to build the module for, it's the numeric value after the hash when you execute 'uname -v' (default 1)
   -l, --loglevel string           log level (default "info")
+      --moduledevicename string   kernel module device name (the default is falco, so the device will be under /dev/falco*) (default "falco")
+      --moduledrivername string   kernel module driver name, i.e. the name you see when you check installed modules via lsmod (default "falco")
       --output-module string      filepath where to save the resulting kernel module
       --output-probe string       filepath where to save the resulting eBPF probe
+      --proxy string              the proxy to use to download data
   -t, --target string             the system to target the build for
       --timeout int               timeout in seconds (default 60)
 ```

--- a/docs/driverkit_kubernetes.md
+++ b/docs/driverkit_kubernetes.md
@@ -22,7 +22,7 @@ driverkit kubernetes [flags]
       --cluster string                 the name of the kubeconfig cluster to use
   -c, --config string                  config file path (default $HOME/.driverkit.yaml if exists)
       --context string                 the name of the kubeconfig context to use
-      --driverversion string           driver version as a git commit hash or as a git tag (default "dev")
+      --driverversion string           driver version as a git commit hash or as a git tag (default "master")
       --dryrun                         do not actually perform the action
   -h, --help                           help for kubernetes
       --insecure-skip-tls-verify       if true, the server's certificate will not be checked for validity, this will make your HTTPS connections insecure
@@ -31,9 +31,12 @@ driverkit kubernetes [flags]
       --kernelversion uint16           kernel version to build the module for, it's the numeric value after the hash when you execute 'uname -v' (default 1)
       --kubeconfig string              path to the kubeconfig file to use for CLI requests
   -l, --loglevel string                log level (default "info")
+      --moduledevicename string        kernel module device name (the default is falco, so the device will be under /dev/falco*) (default "falco")
+      --moduledrivername string        kernel module driver name, i.e. the name you see when you check installed modules via lsmod (default "falco")
   -n, --namespace string               if present, the namespace scope for this CLI request
       --output-module string           filepath where to save the resulting kernel module
       --output-probe string            filepath where to save the resulting eBPF probe
+      --proxy string                   the proxy to use to download data
       --request-timeout string         the length of time to wait before giving up on a single server request, non-zero values should contain a corresponding time unit (e.g, 1s, 2m, 3h), a value of zero means don't timeout requests (default "0")
   -s, --server string                  the address and port of the Kubernetes API server
   -t, --target string                  the system to target the build for

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -113,7 +113,7 @@ func init() {
 		"eq=dev|sha1|semver",
 		T,
 		func(ut ut.Translator) error {
-			return ut.Add("eq=dev|sha1|semver", `{0} must be a valid SHA1, semver-ish, or the "dev" string`, true)
+			return ut.Add("eq=dev|sha1|semver", `{0} must be a valid SHA1, semver-ish, or the "master" string`, true)
 		},
 		func(ut ut.Translator, fe validator.FieldError) string {
 			t, _ := ut.T(fe.Tag(), fe.Field())


### PR DESCRIPTION
Signed-off-by: Leonardo Grasso <me@leonardograsso.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area cmd

> /area pkg

> /area docs

> /area tests


**What this PR does / why we need it**:

The default branch of https://github.com/falcosecurity/libs switched from `dev` to `master` a lot of time ago. This PR updates the default value for `--driverversion` accordingly. 



**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Although having a wrong default value is not strictly a bug, it can cause a bad user experience.

**Does this PR introduce a user-facing change?**:

```release-note
update(cmd): default value for `--driverversion` is now `master`
```
