### PR TITLE
feat(pkg/kernelrelease): introduce json tags for kernelrelease

### DIFF
--- a/pkg/kernelrelease/kernelrelease.go
+++ b/pkg/kernelrelease/kernelrelease.go
@@ -11,12 +11,12 @@ var (
 
 // KernelRelease contains all the version parts.
 type KernelRelease struct {
-	Fullversion      string
-	Version          string
-	PatchLevel       string
-	Sublevel         string
-	Extraversion     string
-	FullExtraversion string
+	Fullversion      string `json:"full_version"`
+	Version          string `json:"version"`
+	PatchLevel       string `json:"patch_level"`
+	Sublevel         string `json:"sublevel"`
+	Extraversion     string `json:"extra_version"`
+	FullExtraversion string `json:"full_extra_version"`
 }
 
 // IsGKE tells whether the current kernel release is for GKE by looking at its name.

--- a/pkg/kernelrelease/kernelrelease_test.go
+++ b/pkg/kernelrelease/kernelrelease_test.go
@@ -2,9 +2,31 @@ package kernelrelease
 
 import (
 	"testing"
+	"encoding/json"
 
 	"gotest.tools/assert"
 )
+
+func TestFromKrToJson(t *testing.T) {
+	test := struct {
+		kernelRelease	KernelRelease
+		want			string
+	}{
+		kernelRelease: KernelRelease{
+			Fullversion:      "5.16.5",
+			Version:          "5",
+			PatchLevel:       "16",
+			Sublevel:         "5",
+			Extraversion:     "arch1-1",
+			FullExtraversion: "-arch1-1",
+		},
+		want: `{"full_version":"5.16.5","version":"5","patch_level":"16","sublevel":"5","extra_version":"arch1-1","full_extra_version":"-arch1-1"}`,
+	}
+	t.Run("version with local version", func(t *testing.T) {
+		got, _ := json.Marshal(test.kernelRelease)
+		assert.Equal(t, test.want, string(got))
+	})
+}
 
 func TestFromString(t *testing.T) {
 	tests := map[string]struct {


### PR DESCRIPTION
This PR introduces JSON tags for the `KernelRelease` struct, with snake case naming convention.

Signed-off-by: maxgio92 <massimiliano.giovagnoli.1992@gmail.com>

**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area pkg
/area tests

**What this PR does / why we need it**:

If we'd need to encode `KernelRelease`s the transformed data will follow the snake case naming convention.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

This PR introduces a test for the struct encoding transformation.

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
feat(pkg/kernelrelease): introduce json tags for kernelrelease
action required: KernelRelease JSON-encoded data fields are renamed following snake case
```
