### PR TITLE
fix(build): support PPM_API_CURRENT_VERSION macros

### DIFF
--- a/pkg/driverbuilder/builder/amazonlinux.go
+++ b/pkg/driverbuilder/builder/amazonlinux.go
@@ -51,7 +51,7 @@ curl --silent -SL {{ .ModuleDownloadURL }} | tar -xzf - -C /tmp/module-download
 mv /tmp/module-download/*/driver/* {{ .DriverBuildDir }}
 
 cp /driverkit/module-Makefile {{ .DriverBuildDir }}/Makefile
-cp /driverkit/module-driver-config.h {{ .DriverBuildDir }}/driver_config.h
+bash /driverkit/fill-driver-config.sh {{ .DriverBuildDir }}
 
 # Fetch the kernel
 mkdir /tmp/kernel-download

--- a/pkg/driverbuilder/builder/centos.go
+++ b/pkg/driverbuilder/builder/centos.go
@@ -185,7 +185,7 @@ curl --silent -SL {{ .ModuleDownloadURL }} | tar -xzf - -C /tmp/module-download
 mv /tmp/module-download/*/driver/* {{ .DriverBuildDir }}
 
 cp /driverkit/module-Makefile {{ .DriverBuildDir }}/Makefile
-cp /driverkit/module-driver-config.h {{ .DriverBuildDir }}/driver_config.h
+bash /driverkit/fill-driver-config.sh {{ .DriverBuildDir }}
 
 # Fetch the kernel
 mkdir /tmp/kernel-download

--- a/pkg/driverbuilder/builder/debian.go
+++ b/pkg/driverbuilder/builder/debian.go
@@ -106,7 +106,7 @@ curl --silent -SL {{ .ModuleDownloadURL }} | tar -xzf - -C /tmp/module-download
 mv /tmp/module-download/*/driver/* {{ .DriverBuildDir }}
 
 cp /driverkit/module-Makefile {{ .DriverBuildDir }}/Makefile
-cp /driverkit/module-driver-config.h {{ .DriverBuildDir }}/driver_config.h
+bash /driverkit/fill-driver-config.sh {{ .DriverBuildDir }}
 
 # Fetch the kernel
 mkdir /tmp/kernel-download

--- a/pkg/driverbuilder/builder/ubuntu.go
+++ b/pkg/driverbuilder/builder/ubuntu.go
@@ -309,7 +309,7 @@ curl --silent -SL {{ .ModuleDownloadURL }} | tar -xzf - -C /tmp/module-download
 mv /tmp/module-download/*/driver/* {{ .DriverBuildDir }}
 
 cp /driverkit/module-Makefile {{ .DriverBuildDir }}/Makefile
-cp /driverkit/module-driver-config.h {{ .DriverBuildDir }}/driver_config.h
+bash /driverkit/fill-driver-config.sh {{ .DriverBuildDir }}
 
 # Fetch the kernel
 mkdir /tmp/kernel-download

--- a/pkg/driverbuilder/builder/vanilla.go
+++ b/pkg/driverbuilder/builder/vanilla.go
@@ -32,7 +32,7 @@ curl --silent -SL {{ .ModuleDownloadURL }} | tar -xzf - -C /tmp/module-download
 mv /tmp/module-download/*/driver/* {{ .DriverBuildDir }}
 
 cp /driverkit/module-Makefile {{ .DriverBuildDir }}/Makefile
-cp /driverkit/module-driver-config.h {{ .DriverBuildDir }}/driver_config.h
+bash /driverkit/fill-driver-config.sh {{ .DriverBuildDir }}
 
 # Fetch the kernel
 cd /tmp

--- a/pkg/driverbuilder/docker.go
+++ b/pkg/driverbuilder/docker.go
@@ -73,8 +73,8 @@ func (bp *DockerBuildProcessor) Start(b *builder.Build) error {
 	}
 
 	// Prepare driver config template
-	bufDriverConfig := bytes.NewBuffer(nil)
-	err = renderDriverConfig(bufDriverConfig, driverConfigData{DriverVersion: c.DriverVersion, DriverName: c.DriverName, DeviceName: c.DeviceName})
+	bufFillDriverConfig := bytes.NewBuffer(nil)
+	err = renderFillDriverConfig(bufFillDriverConfig, driverConfigData{DriverVersion: c.DriverVersion, DriverName: c.DriverName, DeviceName: c.DeviceName})
 	if err != nil {
 		return err
 	}
@@ -145,7 +145,7 @@ func (bp *DockerBuildProcessor) Start(b *builder.Build) error {
 		{"/driverkit/driverkit.sh", driverkitScript},
 		{"/driverkit/kernel.config", string(configDecoded)},
 		{"/driverkit/module-Makefile", bufMakefile.String()},
-		{"/driverkit/module-driver-config.h", bufDriverConfig.String()},
+		{"/driverkit/fill-driver-config.sh", bufFillDriverConfig.String()},
 	}
 
 	var buf bytes.Buffer

--- a/pkg/driverbuilder/kubernetes.go
+++ b/pkg/driverbuilder/kubernetes.go
@@ -105,8 +105,8 @@ func (bp *KubernetesBuildProcessor) buildModule(build *builder.Build) error {
 	}
 
 	// Prepare driver config template
-	bufDriverConfig := bytes.NewBuffer(nil)
-	err = renderDriverConfig(bufDriverConfig, driverConfigData{DriverVersion: c.Build.DriverVersion, DriverName: c.DriverName, DeviceName: c.DeviceName})
+	bufFillDriverConfig := bytes.NewBuffer(nil)
+	err = renderFillDriverConfig(bufFillDriverConfig, driverConfigData{DriverVersion: c.Build.DriverVersion, DriverName: c.DriverName, DeviceName: c.DeviceName})
 	if err != nil {
 		return err
 	}
@@ -126,11 +126,11 @@ func (bp *KubernetesBuildProcessor) buildModule(build *builder.Build) error {
 	cm := &corev1.ConfigMap{
 		ObjectMeta: commonMeta,
 		Data: map[string]string{
-			"driverkit.sh":           res,
-			"kernel.config":          string(configDecoded),
-			"module-Makefile":        bufMakefile.String(),
-			"module-driver-config.h": bufDriverConfig.String(),
-			"module-downloader.sh":   waitForModuleAndCat,
+			"driverkit.sh":          res,
+			"kernel.config":         string(configDecoded),
+			"module-Makefile":       bufMakefile.String(),
+			"fill-driver-config.sh": bufFillDriverConfig.String(),
+			"module-downloader.sh":  waitForModuleAndCat,
 		},
 	}
 	// Construct environment variable array of corev1.EnvVar

--- a/pkg/driverbuilder/templates.go
+++ b/pkg/driverbuilder/templates.go
@@ -74,6 +74,9 @@ type driverConfigData struct {
 
 // XXX both PROBE and DRIVER variables are kept for now so that Driverkit is compatible with older versions.
 // they can be removed when versions from early 2022/late 2021 will not be supported anymore.
+
+// Note that in the future DRIVER_COMMIT will be different from DRIVER_VERSION. Currently, it is the same as the commit
+// and no decision has been made yet about the distinction in falcosecurity/libs. Will need to be updated.
 const fillDriverConfigTemplate = `
 set -euxo pipefail
 

--- a/pkg/driverbuilder/templates.go
+++ b/pkg/driverbuilder/templates.go
@@ -72,6 +72,8 @@ type driverConfigData struct {
 	DeviceName    string
 }
 
+// XXX both PROBE and DRIVER variables are kept for now so that Driverkit is compatible with older versions.
+// they can be removed when versions from early 2022/late 2021 will not be supported anymore.
 const fillDriverConfigTemplate = `
 set -euxo pipefail
 
@@ -85,8 +87,10 @@ cat << EOF > $DRIVER_CONFIG_FILE
 
 #define DRIVER_COMMIT "{{ .DriverVersion }}"
 
+#define PROBE_NAME "{{ .DriverName }}"
 #define DRIVER_NAME "{{ .DriverName }}"
 
+#define PROBE_DEVICE_NAME "{{ .DeviceName }}"
 #define DRIVER_DEVICE_NAME "{{ .DeviceName }}"
 
 #ifndef KBUILD_MODNAME


### PR DESCRIPTION
Signed-off-by: Luca Guerra <luca@guerra.sh>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area cmd

> /area pkg

> /area docs

> /area tests


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

This PR adds support for scap/falco driver versioning, introduced in https://github.com/falcosecurity/libs/pull/39 . Currently, driverkit is broken on any version equal or newer than the above.
Since Driverkit does not use CMake to generate the driver header file, we need to do it at runtime by following the same process that the cmake generator does.

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
fix(build): add support for Falco/Scap driver API versioning macros.
```
