### PR TITLE
fix(driverkit): Bump binutils version, install zstd in base container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ IMAGE_NAME_DRIVERKIT_REF := $(IMAGE_NAME_DRIVERKIT):$(GIT_REF)
 IMAGE_NAME_DRIVERKIT_COMMIT := $(IMAGE_NAME_DRIVERKIT):$(GIT_COMMIT)
 IMAGE_NAME_DRIVERKIT_LATEST := $(IMAGE_NAME_DRIVERKIT):latest
 
-LDFLAGS := -X github.com/falcosecurity/driverkit/pkg/version.buildTime=$(shell date +%s) -X github.com/falcosecurity/driverkit/pkg/version.gitCommit=${GIT_COMMIT} -X github.com/falcosecurity/driverkit/pkg/version.gitTag=$(if ${GIT_TAG},${GIT_TAG},v0.0.0) -X github.com/falcosecurity/driverkit/pkg/version.commitsFromGitTag=${COMMITS_FROM_GIT_TAG} -X github.com/falcosecurity/driverkit/pkg/driverbuilder.builderBaseImage=${IMAGE_NAME_BUILDER_COMMIT}
+LDFLAGS := -X github.com/falcosecurity/driverkit/pkg/version.buildTime=$(shell date +%s) -X github.com/falcosecurity/driverkit/pkg/version.gitCommit=${GIT_COMMIT} -X github.com/falcosecurity/driverkit/pkg/version.gitTag=$(if ${GIT_TAG},${GIT_TAG},v0.0.0) -X github.com/falcosecurity/driverkit/pkg/version.commitsFromGitTag=${COMMITS_FROM_GIT_TAG} -X github.com/falcosecurity/driverkit/pkg/driverbuilder.builderBaseImage=${IMAGE_NAME_BUILDER_LATEST}
 
 OS_NAME := $(shell uname -s | tr A-Z a-z)
 SQLITE_TAGS :=

--- a/build/builder.Dockerfile
+++ b/build/builder.Dockerfile
@@ -34,8 +34,7 @@ RUN apt-get update \
 	lsb-release \
 	wget \
 	software-properties-common \
-	gpg \
-	&& rm -rf /var/lib/apt/lists/*
+	gpg
 
 # Install clang 12
 RUN cd /tmp \
@@ -95,10 +94,14 @@ RUN curl -L -o cpp-4.8_4.8.4-1_amd64.deb https://download.falco.org/dependencies
 
 # debian:stable head contains binutils 2.31, which generates
 # binaries that are incompatible with kernels < 4.16. So manually
-# forcibly install binutils 2.30-22 instead.
-RUN curl -L -o binutils_2.30-22_amd64.deb https://download.falco.org/dependencies/binutils_2.30-22_amd64.deb \
-	&& curl -L -o libbinutils_2.30-22_amd64.deb https://download.falco.org/dependencies/libbinutils_2.30-22_amd64.deb \
-	&& curl -L -o binutils-x86-64-linux-gnu_2.30-22_amd64.deb https://download.falco.org/dependencies/binutils-x86-64-linux-gnu_2.30-22_amd64.deb \
-	&& curl -L -o binutils-common_2.30-22_amd64.deb https://download.falco.org/dependencies/binutils-common_2.30-22_amd64.deb \
+# forcibly install binutils 2.37-7 instead.
+RUN curl -L -o binutils_2.37-7_amd64.deb https://download.falco.org/dependencies/binutils_2.37-7_amd64.deb \
+	&& curl -L -o libbinutils_2.37-7_amd64.deb https://download.falco.org/dependencies/libbinutils_2.37-7_amd64.deb \
+	&& curl -L -o binutils-x86-64-linux-gnu_2.37-7_amd64.deb https://download.falco.org/dependencies/binutils-x86-64-linux-gnu_2.37-7_amd64.deb \
+	&& curl -L -o binutils-common_2.37-7_amd64.deb https://download.falco.org/dependencies/binutils-common_2.37-7_amd64.deb \
 	&& dpkg -i *binutils*.deb \
 	&& rm -f *binutils*.deb
+
+# zstd requires binutils >= 2.31.1 installed above.
+RUN apt-get install -y --no-install-recommends zstd \
+	&& rm -rf /var/lib/apt/lists/*

--- a/build/builder.Dockerfile
+++ b/build/builder.Dockerfile
@@ -34,7 +34,8 @@ RUN apt-get update \
 	lsb-release \
 	wget \
 	software-properties-common \
-	gpg
+	gpg \
+	&& rm -rf /var/lib/apt/lists/*
 
 # Install clang 12
 RUN cd /tmp \
@@ -94,14 +95,10 @@ RUN curl -L -o cpp-4.8_4.8.4-1_amd64.deb https://download.falco.org/dependencies
 
 # debian:stable head contains binutils 2.31, which generates
 # binaries that are incompatible with kernels < 4.16. So manually
-# forcibly install binutils 2.37-7 instead.
-RUN curl -L -o binutils_2.37-7_amd64.deb https://download.falco.org/dependencies/binutils_2.37-7_amd64.deb \
-	&& curl -L -o libbinutils_2.37-7_amd64.deb https://download.falco.org/dependencies/libbinutils_2.37-7_amd64.deb \
-	&& curl -L -o binutils-x86-64-linux-gnu_2.37-7_amd64.deb https://download.falco.org/dependencies/binutils-x86-64-linux-gnu_2.37-7_amd64.deb \
-	&& curl -L -o binutils-common_2.37-7_amd64.deb https://download.falco.org/dependencies/binutils-common_2.37-7_amd64.deb \
+# forcibly install binutils 2.30-22 instead.
+RUN curl -L -o binutils_2.30-22_amd64.deb https://download.falco.org/dependencies/binutils_2.30-22_amd64.deb \
+	&& curl -L -o libbinutils_2.30-22_amd64.deb https://download.falco.org/dependencies/libbinutils_2.30-22_amd64.deb \
+	&& curl -L -o binutils-x86-64-linux-gnu_2.30-22_amd64.deb https://download.falco.org/dependencies/binutils-x86-64-linux-gnu_2.30-22_amd64.deb \
+	&& curl -L -o binutils-common_2.30-22_amd64.deb https://download.falco.org/dependencies/binutils-common_2.30-22_amd64.deb \
 	&& dpkg -i *binutils*.deb \
 	&& rm -f *binutils*.deb
-
-# zstd requires binutils >= 2.31.1 installed above.
-RUN apt-get install -y --no-install-recommends zstd \
-	&& rm -rf /var/lib/apt/lists/*

--- a/pkg/driverbuilder/builder/rocky.go
+++ b/pkg/driverbuilder/builder/rocky.go
@@ -63,7 +63,7 @@ func fetchRockyKernelURLS(kr kernelrelease.KernelRelease) []string {
 	urls := []string{}
 	for _, r := range rockyReleases {
 		urls = append(urls, fmt.Sprintf(
-			"https://download.rockylinux.org/pub/rocky/%s/BaseOS/x86_64/os/Packages/k/kernel-devel-%s%s.rpm"
+			"https://download.rockylinux.org/pub/rocky/%s/BaseOS/x86_64/os/Packages/k/kernel-devel-%s%s.rpm",
 			r,
 			kr.Fullversion,
 			kr.FullExtraversion,

--- a/pkg/driverbuilder/builder/rocky.go
+++ b/pkg/driverbuilder/builder/rocky.go
@@ -31,6 +31,7 @@ func (c rocky) Script(cfg Config) (string, error) {
 
 	// Check (and filter) existing kernels before continuing
 	urls, err := getResolvingURLs(fetchRockyKernelURLS(kr))
+	fmt.Println("urls=%s", urls)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/driverbuilder/builder/rocky.go
+++ b/pkg/driverbuilder/builder/rocky.go
@@ -27,7 +27,7 @@ func (c rocky) Script(cfg Config) (string, error) {
 		return "", err
 	}
 
-	fmt.Sprintf("cfg.Build.KernelRelease=%s", cfg.Build.KernelRelease)
+	fmt.Printf("cfg.Build.KernelRelease=%s", cfg.Build.KernelRelease)
 	kr := kernelrelease.FromString(cfg.Build.KernelRelease)
 
 	// Check (and filter) existing kernels before continuing

--- a/pkg/driverbuilder/builder/rocky.go
+++ b/pkg/driverbuilder/builder/rocky.go
@@ -1,0 +1,139 @@
+package builder
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+
+	"github.com/falcosecurity/driverkit/pkg/kernelrelease"
+)
+
+// TargetTypeRocky identifies the Rocky target.
+const TargetTypeRocky Type = "centos"
+
+func init() {
+	BuilderByTarget[TargetTypeRocky] = &rocky{}
+}
+
+// rocky is a driverkit target.
+type rocky struct {
+}
+
+// Script compiles the script to build the kernel module and/or the eBPF probe.
+func (c rocky) Script(cfg Config) (string, error) {
+	t := template.New(string(TargetTypeRocky))
+	parsed, err := t.Parse(rockyTemplate)
+	if err != nil {
+		return "", err
+	}
+
+	kr := kernelrelease.FromString(cfg.Build.KernelRelease)
+
+	// Check (and filter) existing kernels before continuing
+	urls, err := getResolvingURLs(fetchRockyKernelURLS(kr))
+	if err != nil {
+		return "", err
+	}
+
+	td := rockyTemplateData{
+		DriverBuildDir:    DriverDirectory,
+		ModuleDownloadURL: moduleDownloadURL(cfg),
+		KernelDownloadURL: urls[0],
+		GCCVersion:        rockyGccVersionFromKernelRelease(kr),
+		ModuleDriverName:  cfg.DriverName,
+		ModuleFullPath:    ModuleFullPath,
+		BuildModule:       len(cfg.Build.ModuleFilePath) > 0,
+		BuildProbe:        len(cfg.Build.ProbeFilePath) > 0,
+	}
+
+	buf := bytes.NewBuffer(nil)
+	err = parsed.Execute(buf, td)
+	if err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+func fetchRockyKernelURLS(kr kernelrelease.KernelRelease) []string {
+	rockyReleases := []string{
+		"8",
+		"8.5",
+	}
+
+	urls := []string{}
+	for _, r := range rockyReleases {
+		urls = append(urls, fmt.Sprintf(
+			"https://download.rockylinux.org/pub/rocky/%s/BaseOS/x86_64/os/Packages/k/kernel-devel-%s%s.rpm"
+			r,
+			kr.Fullversion,
+			kr.FullExtraversion,
+		))
+	}
+	return urls
+}
+
+type rockyTemplateData struct {
+	DriverBuildDir    string
+	ModuleDownloadURL string
+	KernelDownloadURL string
+	GCCVersion        string
+	ModuleDriverName  string
+	ModuleFullPath    string
+	BuildModule       bool
+	BuildProbe        bool
+}
+
+const rockyTemplate = `
+#!/bin/bash
+set -xeuo pipefail
+
+rm -Rf {{ .DriverBuildDir }}
+mkdir {{ .DriverBuildDir }}
+rm -Rf /tmp/module-download
+mkdir -p /tmp/module-download
+
+curl --silent -SL {{ .ModuleDownloadURL }} | tar -xzf - -C /tmp/module-download
+mv /tmp/module-download/*/driver/* {{ .DriverBuildDir }}
+
+cp /driverkit/module-Makefile {{ .DriverBuildDir }}/Makefile
+bash /driverkit/fill-driver-config.sh {{ .DriverBuildDir }}
+
+# Fetch the kernel
+mkdir /tmp/kernel-download
+cd /tmp/kernel-download
+curl --silent -o kernel-devel.rpm -SL {{ .KernelDownloadURL }}
+rpm2cpio kernel-devel.rpm | cpio --extract --make-directories
+rm -Rf /tmp/kernel
+mkdir -p /tmp/kernel
+mv usr/src/kernels/*/* /tmp/kernel
+
+# Change current gcc
+ln -sf /usr/bin/gcc-{{ .GCCVersion }} /usr/bin/gcc
+
+{{ if .BuildModule }}
+# Build the module
+cd {{ .DriverBuildDir }}
+make KERNELDIR=/tmp/kernel
+mv {{ .ModuleDriverName }}.ko {{ .ModuleFullPath }}
+strip -g {{ .ModuleFullPath }}
+# Print results
+modinfo {{ .ModuleFullPath }}
+{{ end }}
+
+{{ if .BuildProbe }}
+# Build the eBPF probe
+cd {{ .DriverBuildDir }}/bpf
+make LLC=/usr/bin/llc-7 CLANG=/usr/bin/clang-7 CC=/usr/bin/gcc KERNELDIR=/tmp/kernel
+ls -l probe.o
+{{ end }}
+`
+
+func rockyGccVersionFromKernelRelease(kr kernelrelease.KernelRelease) string {
+	switch kr.Version {
+	case "3":
+		return "5"
+	case "2":
+		return "4.8"
+	}
+	return "8"
+}

--- a/pkg/driverbuilder/builder/rocky.go
+++ b/pkg/driverbuilder/builder/rocky.go
@@ -30,6 +30,7 @@ func (c rocky) Script(cfg Config) (string, error) {
 	kr := kernelrelease.FromString(cfg.Build.KernelRelease)
 
 	// Check (and filter) existing kernels before continuing
+	fmt.Println("kr=%s", kr)
 	urls, err := getResolvingURLs(fetchRockyKernelURLS(kr))
 	fmt.Println("urls=%s", urls)
 	if err != nil {

--- a/pkg/driverbuilder/builder/rocky.go
+++ b/pkg/driverbuilder/builder/rocky.go
@@ -69,6 +69,7 @@ func fetchRockyKernelURLS(kr kernelrelease.KernelRelease) []string {
 			kr.Fullversion,
 			kr.FullExtraversion,
 		))
+		fmt.Println("urls now contains %s", urls)
 	}
 	return urls
 }

--- a/pkg/driverbuilder/builder/rocky.go
+++ b/pkg/driverbuilder/builder/rocky.go
@@ -27,7 +27,6 @@ func (c rocky) Script(cfg Config) (string, error) {
 		return "", err
 	}
 
-	fmt.Printf("cfg.Build.KernelRelease=%s", cfg.Build.KernelRelease)
 	kr := kernelrelease.FromString(cfg.Build.KernelRelease)
 
 	// Check (and filter) existing kernels before continuing

--- a/pkg/driverbuilder/builder/rocky.go
+++ b/pkg/driverbuilder/builder/rocky.go
@@ -27,6 +27,7 @@ func (c rocky) Script(cfg Config) (string, error) {
 		return "", err
 	}
 
+	fmt.Sprintf("cfg.Build.KernelRelease=%s", cfg.Build.KernelRelease)
 	kr := kernelrelease.FromString(cfg.Build.KernelRelease)
 
 	// Check (and filter) existing kernels before continuing

--- a/pkg/driverbuilder/builder/rocky.go
+++ b/pkg/driverbuilder/builder/rocky.go
@@ -9,7 +9,7 @@ import (
 )
 
 // TargetTypeRocky identifies the Rocky target.
-const TargetTypeRocky Type = "centos"
+const TargetTypeRocky Type = "rocky"
 
 func init() {
 	BuilderByTarget[TargetTypeRocky] = &rocky{}

--- a/pkg/driverbuilder/builder/rocky.go
+++ b/pkg/driverbuilder/builder/rocky.go
@@ -30,9 +30,9 @@ func (c rocky) Script(cfg Config) (string, error) {
 	kr := kernelrelease.FromString(cfg.Build.KernelRelease)
 
 	// Check (and filter) existing kernels before continuing
-	fmt.Println("kr=%s", kr)
+	fmt.Printf("kr=%s\n", kr)
 	urls, err := getResolvingURLs(fetchRockyKernelURLS(kr))
-	fmt.Println("urls=%s", urls)
+	fmt.Printf("urls=%s\n", urls)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/driverbuilder/templates.go
+++ b/pkg/driverbuilder/templates.go
@@ -70,6 +70,8 @@ type driverConfigData struct {
 	DriverVersion string
 	DriverName    string
 	DeviceName    string
+	ProbeVersion  string
+	ProbeName     string
 }
 
 // XXX both PROBE and DRIVER variables are kept for now so that Driverkit is compatible with older versions.

--- a/pkg/driverbuilder/templates.go
+++ b/pkg/driverbuilder/templates.go
@@ -87,6 +87,7 @@ cat << EOF > $DRIVER_CONFIG_FILE
 #pragma once
 
 #define DRIVER_VERSION "{{ .DriverVersion }}"
+#define PROBE_VERSION "{{ .ProbeVersion }}"
 
 #define DRIVER_COMMIT "{{ .DriverVersion }}"
 


### PR DESCRIPTION
Signed-off-by: David Windsor <dwindsor@secureworks.com>
Signed-off-by: Logan Bond <lbond@secureworks.com>

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:
/area build


**What this PR does / why we need it**:

When trying to build a driver for newer Ubuntu kernels, `driverkit` fails to extract the downloaded kernel headers package because `zstd` is missing. But, `zstd` requires a version of `binutils` that's more recent than the one on [https://download.falco.org/dependencies](https://download.falco.org/dependencies/), so we need to both:

1) Bump the version of `binutils` hosted on [https://download.falco.org/dependencies](https://download.falco.org/dependencies/) to be >= `2.31.1`
2) Add `zstd` to `build/builder.Dockerfile`

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #127 

**Special notes for your reviewer**:

**NOTE:** We're unable to upload files to download.falco.org, so the URLs to the updated binutils packages will need to be updated by a maintainer after the exact filename has been determined.

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note

```
