### PR TITLE
Add driverbuilder for Rocky Linux

### DIFF
--- a/cmd/testdata/completion-targets.txt
+++ b/cmd/testdata/completion-targets.txt
@@ -2,6 +2,7 @@ amazonlinux
 amazonlinux2
 centos
 debian
+rocky
 ubuntu-aws
 ubuntu-generic
 vanilla

--- a/pkg/driverbuilder/builder/rocky.go
+++ b/pkg/driverbuilder/builder/rocky.go
@@ -1,0 +1,139 @@
+package builder
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+
+	"github.com/falcosecurity/driverkit/pkg/kernelrelease"
+)
+
+// TargetTypeRocky identifies the Rocky target.
+const TargetTypeRocky Type = "rocky"
+
+func init() {
+	BuilderByTarget[TargetTypeRocky] = &rocky{}
+}
+
+// rocky is a driverkit target.
+type rocky struct {
+}
+
+// Script compiles the script to build the kernel module and/or the eBPF probe.
+func (c rocky) Script(cfg Config) (string, error) {
+	t := template.New(string(TargetTypeRocky))
+	parsed, err := t.Parse(rockyTemplate)
+	if err != nil {
+		return "", err
+	}
+
+	kr := kernelrelease.FromString(cfg.Build.KernelRelease)
+
+	// Check (and filter) existing kernels before continuing
+	urls, err := getResolvingURLs(fetchRockyKernelURLS(kr))
+	if err != nil {
+		return "", err
+	}
+
+	td := rockyTemplateData{
+		DriverBuildDir:    DriverDirectory,
+		ModuleDownloadURL: moduleDownloadURL(cfg),
+		KernelDownloadURL: urls[0],
+		GCCVersion:        rockyGccVersionFromKernelRelease(kr),
+		ModuleDriverName:  cfg.DriverName,
+		ModuleFullPath:    ModuleFullPath,
+		BuildModule:       len(cfg.Build.ModuleFilePath) > 0,
+		BuildProbe:        len(cfg.Build.ProbeFilePath) > 0,
+	}
+
+	buf := bytes.NewBuffer(nil)
+	err = parsed.Execute(buf, td)
+	if err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+func fetchRockyKernelURLS(kr kernelrelease.KernelRelease) []string {
+	rockyReleases := []string{
+		"8",
+		"8.5",
+	}
+
+	urls := []string{}
+	for _, r := range rockyReleases {
+		urls = append(urls, fmt.Sprintf(
+			"https://download.rockylinux.org/pub/rocky/%s/BaseOS/x86_64/os/Packages/k/kernel-devel-%s%s.rpm",
+			r,
+			kr.Fullversion,
+			kr.FullExtraversion,
+		))
+	}
+	return urls
+}
+
+type rockyTemplateData struct {
+	DriverBuildDir    string
+	ModuleDownloadURL string
+	KernelDownloadURL string
+	GCCVersion        string
+	ModuleDriverName  string
+	ModuleFullPath    string
+	BuildModule       bool
+	BuildProbe        bool
+}
+
+const rockyTemplate = `
+#!/bin/bash
+set -xeuo pipefail
+
+rm -Rf {{ .DriverBuildDir }}
+mkdir {{ .DriverBuildDir }}
+rm -Rf /tmp/module-download
+mkdir -p /tmp/module-download
+
+curl --silent -SL {{ .ModuleDownloadURL }} | tar -xzf - -C /tmp/module-download
+mv /tmp/module-download/*/driver/* {{ .DriverBuildDir }}
+
+cp /driverkit/module-Makefile {{ .DriverBuildDir }}/Makefile
+bash /driverkit/fill-driver-config.sh {{ .DriverBuildDir }}
+
+# Fetch the kernel
+mkdir /tmp/kernel-download
+cd /tmp/kernel-download
+curl --silent -o kernel-devel.rpm -SL {{ .KernelDownloadURL }}
+rpm2cpio kernel-devel.rpm | cpio --extract --make-directories
+rm -Rf /tmp/kernel
+mkdir -p /tmp/kernel
+mv usr/src/kernels/*/* /tmp/kernel
+
+# Change current gcc
+ln -sf /usr/bin/gcc-{{ .GCCVersion }} /usr/bin/gcc
+
+{{ if .BuildModule }}
+# Build the module
+cd {{ .DriverBuildDir }}
+make KERNELDIR=/tmp/kernel
+mv {{ .ModuleDriverName }}.ko {{ .ModuleFullPath }}
+strip -g {{ .ModuleFullPath }}
+# Print results
+modinfo {{ .ModuleFullPath }}
+{{ end }}
+
+{{ if .BuildProbe }}
+# Build the eBPF probe
+cd {{ .DriverBuildDir }}/bpf
+make LLC=/usr/bin/llc-7 CLANG=/usr/bin/clang-7 CC=/usr/bin/gcc KERNELDIR=/tmp/kernel
+ls -l probe.o
+{{ end }}
+`
+
+func rockyGccVersionFromKernelRelease(kr kernelrelease.KernelRelease) string {
+	switch kr.Version {
+	case "3":
+		return "5"
+	case "2":
+		return "4.8"
+	}
+	return "8"
+}


### PR DESCRIPTION
Signed-off-by: David Windsor <dwindsor@secureworks.com>

```bash

./_output/bin/driverkit -l debug docker --output-module \ /tmp/falco_rocky.ko --kernelversion=1
--kernelrelease=4.18.0-348.el8.0.2.x86_64 --driverversion=b7eb0dd65226a8dc254d228c8d950d07bf3521d2
--moduledrivername="falco_rocky" --moduledevicename="falco-rocky" --target=rocky

DEBU Ifilename:       /tmp/driver/module.ko 
DEBU schema_version: 1.0.0                        
DEBU api_version:    1.0.0                        
DEBU build_commit:   b7eb0dd65226a8dc254d228c8d950d07bf3521d2 
DEBU version:        b7eb0dd65226a8dc254d228c8d950d07bf3521d2 
DEBU author:         the Falco authors            
DEBU license:        GPL                          
DEBU rhelversion:    8.5                          
DEBU srcversion:     FB3CE3C01854B85C4CCF472      
DEBU depends:                                     
DEBU name:           falco_rocky                  
DEBU vermagic:       4.18.0-348.el8.0.2.x86_64 SMP mod_unload modversions  
DEBU parm:           max_consumers:Maximum number of consumers that can simultaneously open the devices (uint) 
DEBU parm:           verbose:Enable verbose logging (bool) 

```


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test
/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:
/area build

> /area cmd

> /area pkg

> /area docs

> /area tests


**What this PR does / why we need it**:

CentOS was EOL'ed in December, 2021. Rocky Linux is the successor to CentOS. Add support to driverkit for building Rocky Linux kernel drivers.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #129 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
new: support for Rocky Linux
```
