### PR TITLE
fix: add back PROBE_VERSION allowing drivers for old falcosecurity/libs versions to be built

### DIFF
--- a/pkg/driverbuilder/templates.go
+++ b/pkg/driverbuilder/templates.go
@@ -86,6 +86,7 @@ DRIVER_CONFIG_FILE="$DRIVER_BUILD_DIR/driver_config.h"
 cat << EOF > $DRIVER_CONFIG_FILE
 #pragma once
 
+#define PROBE_VERSION "{{ .DriverVersion }}"
 #define DRIVER_VERSION "{{ .DriverVersion }}"
 
 #define DRIVER_COMMIT "{{ .DriverVersion }}"


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area cmd

> /area pkg

> /area docs

> /area tests


**What this PR does / why we need it**:

The PR reintroduces PROBE_VERSION define to allow building on old libs versions.
Bug was introduced by: 067a562f25722cdd4bd8fd84f91f412bd671a9d7.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
fix: allow back to build drivers for old libs versions
```
