### PR TITLE
Upgrade binutils and install zstd in base builder

### DIFF
--- a/build/builder.Dockerfile
+++ b/build/builder.Dockerfile
@@ -34,8 +34,7 @@ RUN apt-get update \
 	lsb-release \
 	wget \
 	software-properties-common \
-	gpg \
-	&& rm -rf /var/lib/apt/lists/*
+	gpg
 
 # Install clang 12
 RUN cd /tmp \
@@ -96,9 +95,13 @@ RUN curl -L -o cpp-4.8_4.8.4-1_amd64.deb https://download.falco.org/dependencies
 # debian:stable head contains binutils 2.31, which generates
 # binaries that are incompatible with kernels < 4.16. So manually
 # forcibly install binutils 2.30-22 instead.
-RUN curl -L -o binutils_2.30-22_amd64.deb https://download.falco.org/dependencies/binutils_2.30-22_amd64.deb \
-	&& curl -L -o libbinutils_2.30-22_amd64.deb https://download.falco.org/dependencies/libbinutils_2.30-22_amd64.deb \
-	&& curl -L -o binutils-x86-64-linux-gnu_2.30-22_amd64.deb https://download.falco.org/dependencies/binutils-x86-64-linux-gnu_2.30-22_amd64.deb \
-	&& curl -L -o binutils-common_2.30-22_amd64.deb https://download.falco.org/dependencies/binutils-common_2.30-22_amd64.deb \
+RUN curl -L -o binutils_2.37-7_amd64.deb https://download.falco.org/dependencies/binutils_2.37-7_amd64.deb \
+	&& curl -L -o libbinutils_2.37-7_amd64.deb https://download.falco.org/dependencies/libbinutils_2.37-7_amd64.deb \
+	&& curl -L -o binutils-x86-64-linux-gnu_2.37-7_amd64.deb https://download.falco.org/dependencies/binutils-x86-64-linux-gnu_2.37-7_amd64.deb \
+	&& curl -L -o binutils-common_2.37-7_amd64.deb https://download.falco.org/dependencies/binutils-common_2.37-7_amd64.deb \
 	&& dpkg -i *binutils*.deb \
 	&& rm -f *binutils*.deb
+
+# zstd requires binutils >= 2.31.1 installed above.
+RUN apt-get install -y --no-install-recommends zstd \
+	&& rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Signed-off-by: David Windsor <dwindsor@secureworks.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build



**What this PR does / why we need it**:

When trying to build a driver for newer Ubuntu kernels, `driverkit` fails to extract the downloaded kernel headers package because `zstd` is missing. But, `zstd` requires a version of `binutils` that's more recent than the one on [https://download.falco.org/dependencies](https://download.falco.org/dependencies/), so we need to both:

1) Bump the version of `binutils` hosted on [https://download.falco.org/dependencies](https://download.falco.org/dependencies/) to be >= `2.31.1`
2) Add `zstd` to `build/builder.Dockerfile`

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #127 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note

```
