### PR TITLE
Fix: Add 5.10 series kernels to amazonlinux2 builder

### DIFF
--- a/pkg/driverbuilder/builder/amazonlinux.go
+++ b/pkg/driverbuilder/builder/amazonlinux.go
@@ -64,6 +64,8 @@ rm -rf kernel.rpm
 rm -Rf /tmp/kernel
 mkdir -p /tmp/kernel
 mv usr/src/kernels/*/* /tmp/kernel
+sed -i 's/PROBE_VERSION/DRIVER_VERSION/g' /tmp/driver/main.c
+sed -i 's/PPM_IOCTL_GET_DRIVER_VERSION/PPM_IOCTL_GET_PROBE_VERSION/g' /tmp/driver/main.c
 
 # Change current gcc
 ln -sf /usr/bin/gcc /usr/bin/gcc-{{ .GCCVersion }}
@@ -90,7 +92,7 @@ type amazonlinuxTemplateData struct {
 	DriverBuildDir     string
 	ModuleDownloadURL  string
 	KernelDownloadURLs []string
-	GCCVersion		   string
+	GCCVersion         string
 	ModuleDriverName   string
 	ModuleFullPath     string
 	BuildModule        bool

--- a/pkg/driverbuilder/builder/amazonlinux.go
+++ b/pkg/driverbuilder/builder/amazonlinux.go
@@ -147,6 +147,7 @@ var reposByTarget = map[Type][]string{
 		"core/2.0",
 		"core/latest",
 		"extras/kernel-5.4/latest",
+		"extras/kernel-5.10/latest",
 	},
 	TargetTypeAmazonLinux: []string{
 		"latest/updates",

--- a/pkg/driverbuilder/builder/amazonlinux.go
+++ b/pkg/driverbuilder/builder/amazonlinux.go
@@ -64,8 +64,6 @@ rm -rf kernel.rpm
 rm -Rf /tmp/kernel
 mkdir -p /tmp/kernel
 mv usr/src/kernels/*/* /tmp/kernel
-sed -i 's/PROBE_VERSION/DRIVER_VERSION/g' /tmp/driver/main.c
-sed -i 's/PPM_IOCTL_GET_DRIVER_VERSION/PPM_IOCTL_GET_PROBE_VERSION/g' /tmp/driver/main.c
 
 # Change current gcc
 ln -sf /usr/bin/gcc /usr/bin/gcc-{{ .GCCVersion }}


### PR DESCRIPTION
Signed-off-by: David Windsor <dwindsor@octolabs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area cmd

> /area pkg

> /area docs

> /area tests


**What this PR does / why we need it**:

Currently, the AmazonLinux2 builder won't build configs for the latest kernels:

![Screen Shot 2022-04-20 at 11 23 30 AM](https://user-images.githubusercontent.com/934449/164272376-4fdde847-9db8-45d7-8207-7009834ae378.png)

Expected behavior:

![Screen Shot 2022-04-20 at 11 48 08 AM](https://user-images.githubusercontent.com/934449/164272452-3539e5f7-43f9-49b2-93a1-b26a1c87fc9c.png)


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #137

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note

```
