### PR TITLE
Fix: Ability to build 5.10 module and eBPF probe on AmazonLinux2

### DIFF
--- a/pkg/driverbuilder/builder/amazonlinux.go
+++ b/pkg/driverbuilder/builder/amazonlinux.go
@@ -64,6 +64,8 @@ rm -rf kernel.rpm
 rm -Rf /tmp/kernel
 mkdir -p /tmp/kernel
 mv usr/src/kernels/*/* /tmp/kernel
+sed -i 's/PROBE_VERSION/DRIVER_VERSION/g' /tmp/driver/main.c
+sed -i 's/PPM_IOCTL_GET_DRIVER_VERSION/PPM_IOCTL_GET_PROBE_VERSION/g' /tmp/driver/main.c
 
 # Change current gcc
 ln -sf /usr/bin/gcc /usr/bin/gcc-{{ .GCCVersion }}
@@ -90,7 +92,7 @@ type amazonlinuxTemplateData struct {
 	DriverBuildDir     string
 	ModuleDownloadURL  string
 	KernelDownloadURLs []string
-	GCCVersion		   string
+	GCCVersion         string
 	ModuleDriverName   string
 	ModuleFullPath     string
 	BuildModule        bool

--- a/pkg/driverbuilder/builder/amazonlinux.go
+++ b/pkg/driverbuilder/builder/amazonlinux.go
@@ -147,6 +147,7 @@ var reposByTarget = map[Type][]string{
 		"core/2.0",
 		"core/latest",
 		"extras/kernel-5.4/latest",
+		"extras/kernel-5.10/latest",
 	},
 	TargetTypeAmazonLinux: []string{
 		"latest/updates",

--- a/pkg/driverbuilder/builder/amazonlinux.go
+++ b/pkg/driverbuilder/builder/amazonlinux.go
@@ -64,8 +64,6 @@ rm -rf kernel.rpm
 rm -Rf /tmp/kernel
 mkdir -p /tmp/kernel
 mv usr/src/kernels/*/* /tmp/kernel
-sed -i 's/PROBE_VERSION/DRIVER_VERSION/g' /tmp/driver/main.c
-sed -i 's/PPM_IOCTL_GET_DRIVER_VERSION/PPM_IOCTL_GET_PROBE_VERSION/g' /tmp/driver/main.c
 
 # Change current gcc
 ln -sf /usr/bin/gcc /usr/bin/gcc-{{ .GCCVersion }}


### PR DESCRIPTION
# Summary
Based off of https://github.com/falcosecurity/driverkit/pull/138 by @dwindsor (which was closed in favor of this PR). This fixes #137 for newer amazonlinux2 kernels.

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

**What this PR does / why we need it**:

Please see reference in #138 

Additional details are without the change of LLVM version on 5.10 kernels we get the following error (debug logging enabled)
```
 ❯ ./_output/bin/driverkit docker --output-probe /tmp/probe.o --kernelversion=1 --kernelrelease="5.10.109-104.500.amzn2.x86_64" --driverversion=3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4 --target=amazonlinux2 -l debug
DEBU running without a configuration file
DEBU running with options                          driverversion=3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4 kernelrelease=5.10.109-104.500.amzn2.x86_64 kernelversion=1 output-probe=/tmp/probe.o target=amazonlinux2
INFO driver building, it will take a few seconds   processor=docker
DEBU doing a new docker build
DEBU looking for repo...                           url="http://amazonlinux.us-east-1.amazonaws.com/2/core/2.0/x86_64/mirror.list" version=core/2.0
DEBU downloading...                                url="http://amazonlinux.us-east-1.amazonaws.com/2/core/2.0/x86_64/cb59f2813ac390d40ecac3b1ba25c701b900c6cc8e1d71b705c0b88c234672dd/repodata/primary.sqlite.gz"
DEBU connecting to database...                     db=/var/folders/2r/n9f8qcwj7ds6k5h3fkxcmtj00000gp/T/amazonlinux2-935739517.sqlite
DEBU looking for repo...                           url="http://amazonlinux.us-east-1.amazonaws.com/2/core/latest/x86_64/mirror.list" version=core/latest
DEBU looking for repo...                           url="http://amazonlinux.us-east-1.amazonaws.com/2/extras/kernel-5.4/latest/x86_64/mirror.list" version=extras/kernel-5.4/latest
DEBU downloading...                                url="http://amazonlinux.us-east-1.amazonaws.com/2/extras/kernel-5.4/stable/x86_64/5859ce74bec5ec2d7c97966e5e179f31474f1b92ce2e84dca0e6c253db912ded/repodata/primary.sqlite.gz"
DEBU connecting to database...                     db=/var/folders/2r/n9f8qcwj7ds6k5h3fkxcmtj00000gp/T/amazonlinux2-742013368.sqlite
DEBU looking for repo...                           url="http://amazonlinux.us-east-1.amazonaws.com/2/extras/kernel-5.10/latest/x86_64/mirror.list" version=extras/kernel-5.10/latest
DEBU downloading...                                url="http://amazonlinux.us-east-1.amazonaws.com/2/extras/kernel-5.10/stable/x86_64/0510ac29f090c4abb8f1e512caf638f428653cdefd83bee7b60f141b7691af92/repodata/primary.sqlite.gz"
DEBU connecting to database...                     db=/var/folders/2r/n9f8qcwj7ds6k5h3fkxcmtj00000gp/T/amazonlinux2-738964919.sqlite
DEBU kernel header url found                       url="http://amazonlinux.us-east-1.amazonaws.com/blobstore/ca19e72b4e6b43af5c589209d1c44211800e1fd556633a0359f8e50c6b9dfacc/kernel-devel-5.10.109-104.500.amzn2.x86_64.rpm"
DEBU kernel header url found                       url="http://amazonlinux.us-east-1.amazonaws.com/blobstore/9b5902730105383e33cb83e5271b8fcaefc7af1538cac04566b34d2215bba402/kernel-5.10.109-104.500.amzn2.x86_64.rpm"
DEBU + rm -Rf /tmp/driver
DEBU + mkdir /tmp/driver
DEBU + rm -Rf /tmp/module-download
DEBU  + mkdir -p /tmp/module-download
DEBU r+ curl --silent -SL https://github.com/falcosecurity/libs/archive/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4.tar.gz
DEBU %+ tar -xzf - -C /tmp/module-download
DEBU    + mv /tmp/module-download/libs-3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/driver/CMakeLists.txt /tmp/module-download/libs-3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/driver/GPL2.txt /tmp/module-download/libs-3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/driver/MIT.txt /tmp/module-download/libs-3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/driver/Makefile.in /tmp/module-download/libs-3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/driver/bpf /tmp/module-download/libs-3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/driver/dkms.conf.in /tmp/module-download/libs-3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/driver/driver_config.h.in /tmp/module-download/libs-3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/driver/dynamic_params_table.c /tmp/module-download/libs-3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/driver/event_table.c /tmp/module-download/libs-3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/driver/fillers_table.c /tmp/module-download/libs-3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/driver/flags_table.c /tmp/module-download/libs-3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/driver/kernel_hacks.h /tmp/module-download/libs-3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/driver/main.c /tmp/module-download/libs-3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/driver/ppm.h /tmp/module-download/libs-3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/driver/ppm_compat_unistd_32.h /tmp/module-download/libs-3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/driver/ppm_cputime.c /tmp/module-download/libs-3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/driver/ppm_events.c /tmp/module-download/libs-3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/driver/ppm_events.h /tmp/module-download/libs-3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/driver/ppm_events_public.h /tmp/module-download/libs-3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/driver/ppm_fillers.c /tmp/module-download/libs-3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/driver/ppm_fillers.h /tmp/module-download/libs-3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/driver/ppm_flag_helpers.h /tmp/module-download/libs-3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/driver/ppm_ringbuffer.h /tmp/module-download/libs-3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/driver/ppm_syscall.h /tmp/module-download/libs-3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/driver/ppm_version.h /tmp/module-download/libs-3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/driver/syscall_table.c /tmp/driver
DEBU 5+ cp /driverkit/module-Makefile /tmp/driver/Makefile
DEBU 4+ bash /driverkit/fill-driver-config.sh /tmp/driver
DEBU V+ DRIVER_BUILD_DIR=/tmp/driver
DEBU + DRIVER_CONFIG_FILE=/tmp/driver/driver_config.h
DEBU + cat
DEBU N+ API_VERSION_FILE=/tmp/driver/API_VERSION
DEBU + [[ -f /tmp/driver/API_VERSION ]]
DEBU 1+ SCHEMA_VERSION_FILE=/tmp/driver/SCHEMA_VERSION
DEBU &+ [[ -f /tmp/driver/SCHEMA_VERSION ]]
DEBU 1+ SCHEMA_VERSION_FILE=/tmp/driver/SCHEMA_VERSION
DEBU &+ [[ -f /tmp/driver/SCHEMA_VERSION ]]
DEBU + mkdir /tmp/kernel-download
DEBU + cd /tmp/kernel-download
DEBU + curl --silent -o kernel.rpm -SL http://amazonlinux.us-east-1.amazonaws.com/blobstore/ca19e72b4e6b43af5c589209d1c44211800e1fd556633a0359f8e50c6b9dfacc/kernel-devel-5.10.109-104.500.amzn2.x86_64.rpm
DEBU :+ rpm2cpio kernel.rpm
DEBU + cpio --extract --make-directories
DEBU 164871 blocks
DEBU + rm -rf kernel.rpm
DEBU + curl --silent -o kernel.rpm -SL http://amazonlinux.us-east-1.amazonaws.com/blobstore/9b5902730105383e33cb83e5271b8fcaefc7af1538cac04566b34d2215bba402/kernel-5.10.109-104.500.amzn2.x86_64.rpm
DEBU :+ rpm2cpio kernel.rpm
DEBU + cpio --extract --make-directories
DEBU 215887 blocks
DEBU + rm -rf kernel.rpm
DEBU + rm -Rf /tmp/kernel
DEBU + mkdir -p /tmp/kernel
DEBU w+ mv usr/src/kernels/5.10.109-104.500.amzn2.x86_64/Kconfig usr/src/kernels/5.10.109-104.500.amzn2.x86_64/Makefile usr/src/kernels/5.10.109-104.500.amzn2.x86_64/Makefile.kernel usr/src/kernels/5.10.109-104.500.amzn2.x86_64/Module.symvers usr/src/kernels/5.10.109-104.500.amzn2.x86_64/System.map usr/src/kernels/5.10.109-104.500.amzn2.x86_64/arch usr/src/kernels/5.10.109-104.500.amzn2.x86_64/block usr/src/kernels/5.10.109-104.500.amzn2.x86_64/certs usr/src/kernels/5.10.109-104.500.amzn2.x86_64/crypto usr/src/kernels/5.10.109-104.500.amzn2.x86_64/drivers usr/src/kernels/5.10.109-104.500.amzn2.x86_64/fs usr/src/kernels/5.10.109-104.500.amzn2.x86_64/include usr/src/kernels/5.10.109-104.500.amzn2.x86_64/init usr/src/kernels/5.10.109-104.500.amzn2.x86_64/ipc usr/src/kernels/5.10.109-104.500.amzn2.x86_64/kernel usr/src/kernels/5.10.109-104.500.amzn2.x86_64/lib usr/src/kernels/5.10.109-104.500.amzn2.x86_64/mm usr/src/kernels/5.10.109-104.500.amzn2.x86_64/net usr/src/kernels/5.10.109-104.500.amzn2.x86_64/samples usr/src/kernels/5.10.109-104.500.amzn2.x86_64/scripts usr/src/kernels/5.10.109-104.500.amzn2.x86_64/security usr/src/kernels/5.10.109-104.500.amzn2.x86_64/sound usr/src/kernels/5.10.109-104.500.amzn2.x86_64/tools usr/src/kernels/5.10.109-104.500.amzn2.x86_64/usr usr/src/kernels/5.10.109-104.500.amzn2.x86_64/virt usr/src/kernels/5.10.109-104.500.amzn2.x86_64/vmlinux.id /tmp/kernel
DEBU &+ ln -sf /usr/bin/gcc /usr/bin/gcc-10
DEBU l+ cd /tmp/driver/bpf
DEBU + make LLC=/usr/bin/llc-7 CLANG=/usr/bin/clang-7 CC=/usr/bin/gcc KERNELDIR=/tmp/kernel
DEBU ake -C /tmp/kernel M=$PWD
DEBU make[1]: Entering directory '/tmp/kernel'
DEBU make -f Makefile.kernel CROSS_COMPILE="gcc10-" CC="/usr/bin/gcc" HOSTCC="gcc10-gcc" HOSTCXX="gcc10-g++" LD="gcc10-ld.bfd" modules
DEBU *make[2]: Entering directory '/tmp/kernel'
DEBU Nscripts/Makefile.lib:8: 'always' is deprecated. Please use 'always-y' instead
DEBU /usr/bin/clang-7 -I./arch/x86/include -I./arch/x86/include/generated  -I./include -I./arch/x86/include/uapi -I./arch/x86/include/generated/uapi -I./include/uapi -I./include/generated/uapi -include ./include/linux/kconfig.h \
DEBU    -D__KERNEL__ -fmacro-prefix-map=./=  \
DEBU     \
DEBU     \
DEBU    -D__KERNEL__ \
DEBU    -D__BPF_TRACING__ \
DEBU    -Wno-gnu-variable-sized-type-not-at-end \
DEBU    -Wno-address-of-packed-member \
DEBU    -fno-jump-tables \
DEBU    -fno-stack-protector \
DEBU    -Wno-tautological-compare \
DEBU    -O2 -g -emit-llvm -c /tmp/driver/bpf/probe.c -o /tmp/driver/bpf/probe.ll
DEBU 9clang: error: unknown argument: '-fmacro-prefix-map=./='
DEBU Lmake[3]: *** [/tmp/driver/bpf/Makefile:35: /tmp/driver/bpf/probe.o] Error 1
DEBU =make[2]: *** [Makefile.kernel:1822: /tmp/driver/bpf] Error 2
DEBU )make[2]: Leaving directory '/tmp/kernel'
DEBU )make[1]: Leaving directory '/tmp/kernel'
DEBU +make[1]: *** [Makefile:9: modules] Error 2
DEBU %make: *** [Makefile:20: all] Error 2
DEBU log pipe close                                error=EOF
DEBU context canceled
FATA exiting                                       error="Error: No such container:path: 5d48462fbfb7c83b2a85998dff191faa9bf6b8c8d5df25a6c93186a956d610cd:/tmp/driver/bpf/probe.o"
```

With this, the probe and kernel now build successfully