### PR TITLE
fix: reversed symbolic link in amazonlinux2 builder script

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.6.3
-	golang.org/x/sys v0.0.0-20191210023423-ac6580df4449 // indirect
+	golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 // indirect
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.17.3
 	k8s.io/apimachinery v0.17.3

--- a/go.sum
+++ b/go.sum
@@ -384,6 +384,8 @@ golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456 h1:ng0gs1AKnRRuEMZoTLLlbOd+C
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191210023423-ac6580df4449 h1:gSbV7h1NRL2G1xTg/owz62CST1oJBmxy4QpMMregXVQ=
 golang.org/x/sys v0.0.0-20191210023423-ac6580df4449/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 h1:xHms4gcpe1YE7A3yIllJXP16CMAGuqwO2lX1mTyyRRc=
+golang.org/x/sys v0.0.0-20220422013727-9388b58f7150/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/driverbuilder/builder/amazonlinux.go
+++ b/pkg/driverbuilder/builder/amazonlinux.go
@@ -66,7 +66,7 @@ mkdir -p /tmp/kernel
 mv usr/src/kernels/*/* /tmp/kernel
 
 # Change current gcc
-ln -sf /usr/bin/gcc /usr/bin/gcc-{{ .GCCVersion }}
+ln -sf /usr/bin/gcc-{{ .GCCVersion }} /usr/bin/gcc
 
 {{ if .BuildModule }}
 # Build the kernel module
@@ -327,21 +327,16 @@ func bunzip(data io.Reader) (res []byte, err error) {
 }
 
 func amazonGccVersionFromKernelRelease(kr kernelrelease.KernelRelease) string {
-	switch kr.Version {
-	case "5":
-		return "10"
-	}
 	return "8"
 }
 
 func amazonLLVMVersionFromKernelRelease(kr kernelrelease.KernelRelease) string {
 	switch kr.Version {
-	case "5":
-		switch kr.PatchLevel {
-		case "10":
-			return "12"
-		}
+	case "4":
 		return "7"
+	case "5":
+		return "12"
+	default:
+		return "12"
 	}
-	return "7"
 }


### PR DESCRIPTION
* reversed symbolic link in amazonlinux2 builder script 
* updated a package version required for building on macOS as that seems to have broken

Signed-off-by: Austin Brogle <abrogle@snapchat.com>

**What type of PR is this?**
/kind bug

**Any specific area of the project related to this PR?**
/area pkg


**What this PR does / why we need it**:
Currently we had a lot of build errors with this new driverkit version in Prow build of test-infra https://prow.falco.org/view/s3/falco-prow-logs/logs/rebuild-all-drivers-amazonlinux2-periodic/1518943763240587264 which means that this repo is currently broken for amazonlinux2.

This was caused by a couple things:
1. A reversed symbolic link which caused an infinite loop of symbolic links when gcc pointed at gcc-8 by default and then we made gcc-8 point at gcc.
2. Attempting to build 4.9.x probes as this is not supported (these were removed from test-infra configs in https://github.com/falcosecurity/test-infra/pull/682


I also updated the x/sys library as this stopped building on my macOS machine until I did that.

I also made llvm-12 the default probe builder for any newer kernels that will be released of amazonlinux2

**Testing Done**
I wrote a script that run the driverkit docker builder over all of the following kernels for the eBPF probe and the kernel module and it was successful
```
4.14.101-91.76.amzn2.x86_64
4.14.104-95.84.amzn2.x86_64
4.14.106-97.85.amzn2.x86_64
4.14.109-99.92.amzn2.x86_64
4.14.114-103.97.amzn2.x86_64
4.14.114-105.126.amzn2.x86_64
4.14.121-109.96.amzn2.x86_64
4.14.123-111.109.amzn2.x86_64
4.14.128-112.105.amzn2.x86_64
4.14.133-113.105.amzn2.x86_64
4.14.133-113.112.amzn2.x86_64
4.14.138-114.102.amzn2.x86_64
4.14.143-118.123.amzn2.x86_64
4.14.146-119.123.amzn2.x86_64
4.14.146-120.181.amzn2.x86_64
4.14.152-124.171.amzn2.x86_64
4.14.152-127.182.amzn2.x86_64
4.14.154-128.181.amzn2.x86_64
4.14.158-129.185.amzn2.x86_64
4.14.165-131.185.amzn2.x86_64
4.14.165-133.209.amzn2.x86_64
4.14.171-136.231.amzn2.x86_64
4.14.173-137.228.amzn2.x86_64
4.14.173-137.229.amzn2.x86_64
4.14.177-139.253.amzn2.x86_64
4.14.177-139.254.amzn2.x86_64
4.14.181-140.257.amzn2.x86_64
4.14.181-142.260.amzn2.x86_64
4.14.186-146.268.amzn2.x86_64
4.14.192-147.314.amzn2.x86_64
4.14.193-149.317.amzn2.x86_64
4.14.198-152.320.amzn2.x86_64
4.14.200-155.322.amzn2.x86_64
4.14.203-156.332.amzn2.x86_64
4.14.209-160.335.amzn2.x86_64
4.14.209-160.339.amzn2.x86_64
4.14.214-160.339.amzn2.x86_64
4.14.219-161.340.amzn2.x86_64
4.14.219-164.354.amzn2.x86_64
4.14.225-168.357.amzn2.x86_64
4.14.225-169.362.amzn2.x86_64
4.14.231-173.360.amzn2.x86_64
4.14.231-173.361.amzn2.x86_64
4.14.232-176.381.amzn2.x86_64
4.14.232-177.418.amzn2.x86_64
4.14.238-182.421.amzn2.x86_64
4.14.238-182.422.amzn2.x86_64
4.14.241-184.433.amzn2.x86_64
4.14.243-185.433.amzn2.x86_64
4.14.246-187.474.amzn2.x86_64
4.14.248-189.473.amzn2.x86_64
4.14.252-195.481.amzn2.x86_64
4.14.252-195.483.amzn2.x86_64
4.14.256-197.484.amzn2.x86_64
4.14.26-54.32.amzn2.x86_64
4.14.262-200.489.amzn2.x86_64
4.14.268-205.500.amzn2.x86_64
4.14.273-207.502.amzn2.x86_64
4.14.33-59.34.amzn2.x86_64
4.14.33-59.37.amzn2.x86_64
4.14.42-61.37.amzn2.x86_64
4.14.47-63.37.amzn2.x86_64
4.14.47-64.38.amzn2.x86_64
4.14.51-66.38.amzn2.x86_64
4.14.55-68.37.amzn2.x86_64
4.14.59-68.43.amzn2.x86_64
4.14.62-70.117.amzn2.x86_64
4.14.67-71.56.amzn2.x86_64
4.14.70-72.55.amzn2.x86_64
4.14.72-73.55.amzn2.x86_64
4.14.77-80.57.amzn2.x86_64
4.14.77-81.59.amzn2.x86_64
4.14.77-86.82.amzn2.x86_64
4.14.88-88.73.amzn2.x86_64
4.14.88-88.76.amzn2.x86_64
4.14.94-89.73.amzn2.x86_64
4.14.97-90.72.amzn2.x86_64
5.4.105-48.177.amzn2.x86_64
5.4.110-54.182.amzn2.x86_64
5.4.110-54.189.amzn2.x86_64
5.4.117-58.216.amzn2.x86_64
5.4.129-62.227.amzn2.x86_64
5.4.129-63.229.amzn2.x86_64
5.4.141-67.229.amzn2.x86_64
5.4.144-69.257.amzn2.x86_64
5.4.149-73.259.amzn2.x86_64
5.4.156-83.273.amzn2.x86_64
5.4.162-86.275.amzn2.x86_64
5.4.172-90.336.amzn2.x86_64
5.4.176-91.338.amzn2.x86_64
5.4.181-99.354.amzn2.x86_64
5.4.186-102.354.amzn2.x86_64
5.4.20-12.75.amzn2.x86_64
5.4.38-17.76.amzn2.x86_64
5.4.46-19.75.amzn2.x86_64
5.4.46-23.77.amzn2.x86_64
5.4.50-25.83.amzn2.x86_64
5.4.58-27.104.amzn2.x86_64
5.4.58-32.125.amzn2.x86_64
5.4.68-34.125.amzn2.x86_64
5.4.74-36.135.amzn2.x86_64
5.4.80-40.140.amzn2.x86_64
5.4.91-41.139.amzn2.x86_64
5.4.95-42.163.amzn2.x86_64
5.10.102-99.473.amzn2.x86_64
5.10.106-102.504.amzn2.x86_64
5.10.29-27.126.amzn2.x86_64
5.10.29-27.128.amzn2.x86_64
5.10.35-31.135.amzn2.x86_64
5.10.47-39.130.amzn2.x86_64
5.10.50-44.131.amzn2.x86_64
5.10.50-44.132.amzn2.x86_64
5.10.59-52.142.amzn2.x86_64
5.10.62-55.141.amzn2.x86_64
5.10.68-62.173.amzn2.x86_64
5.10.75-79.358.amzn2.x86_64
5.10.82-83.359.amzn2.x86_64
5.10.93-87.444.amzn2.x86_64
5.10.96-90.460.amzn2.x86_64
```

I ran the kernel module builder over these kernels since only the module is supported on 4.9
```
4.9.62-10.57.amzn2.x86_64
4.9.70-2.243.amzn2.x86_64
4.9.75-1.56.amzn2.x86_64
4.9.76-38.79.amzn2.x86_64
4.9.77-41.59.amzn2.x86_64
4.9.81-44.57.amzn2.x86_64
4.9.85-46.56.amzn2.x86_64
4.9.85-47.59.amzn2.x86_64
```

All successfully ran.