### PR TITLE
new(ci): added arm64 ci build and tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,17 +1,64 @@
-version: 2
+version: 2.1
 jobs:
-  "test":
+  "build-test":
     docker:
-      - image: docker.io/golang:1.17.0
+      - image: alpine:3.16
     steps:
       - checkout
       - run:
+          name: Install deps
+          command: apk add gcc musl-dev make bash git go
+      - run:
+          name: Build
+          command: make build
+      - run:
           name: Test
           command: make test
+      - run:
+          name: Prepare Artifacts
+          command: |
+            mkdir -p /tmp/build-amd64
+            cp _output/bin/driverkit /tmp/build-amd64/
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+            - build-amd64/
+  "build-test-arm64":
+    machine:
+      enabled: true
+      image: ubuntu-2004:2022.04.1
+    resource_class: arm.medium
+    steps:
+      - checkout:
+          path: /tmp/source
+      - run:
+          name: Prepare project
+          command: |
+            docker run --rm -it -v /tmp/source:/source -w /source --name alpine_sh -d alpine:3.16 sh
+            docker exec alpine_sh apk add gcc musl-dev make bash git go
+            docker exec alpine_sh git config --global --add safe.directory /source
+      - run:
+          name: Build
+          command: docker exec alpine_sh make build
+      - run:
+          name: Test
+          command: docker exec alpine_sh make test
+      - run:
+          name: Prepare Artifacts
+          command: |
+            mkdir -p /tmp/build-arm64
+            cp /tmp/source/_output/bin/driverkit /tmp/build-arm64/     
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+            - build-arm64/
   "images":
     docker:
       - image: cimg/base:stable
+        user: root
     steps:
+      - attach_workspace:
+          at: /
       - checkout
       - setup_remote_docker:
           version: 20.10.12
@@ -24,6 +71,10 @@ jobs:
             echo ${DOCKERHUB_SECRET} | docker login -u ${DOCKERHUB_USER} --password-stdin
             sudo apt update
             sudo apt install make bash git
+      - run:
+          name: Copy binaries from workspace
+          command: |
+            cp -r /build-* .
       - run:
           name: Build and Push all docker images
           command: |
@@ -52,10 +103,14 @@ jobs:
           name: Release
           command: GIT_TAG="$CIRCLE_TAG" make release
 workflows:
-  version: 2
+  version: 2.1
   build:
     jobs:
-      - "test":
+      - "build-test":
+          filters:
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*(-.*)*/
+      - "build-test-arm64":
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*(-.*)*/
@@ -68,7 +123,8 @@ workflows:
             tags:
               only: /v[0-9]+(\.[0-9]+)*(-.*)*/
           requires:
-            - "test"
+            - "build-test"
+            - "build-test-arm64"
       - "release":
           context: falco
           filters:
@@ -77,5 +133,4 @@ workflows:
             tags:
               only: /v[0-9]+(\.[0-9]+)*(-.*)*/
           requires:
-            - "test"
             - "images"

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ push/latest:
 .PHONY: test
 test:
 	go test -v -race ./...
-	go test -v ./cmd
+	go test -v -buildmode=pie ./cmd
 
 .PHONY: ${driverkit_docgen}
 ${driverkit_docgen}: ${PWD}/docgen

--- a/build/driverkit.Dockerfile
+++ b/build/driverkit.Dockerfile
@@ -1,14 +1,6 @@
-FROM docker.io/golang:1.17-alpine3.16 as builder
-
-LABEL maintainer="cncf-falco-dev@lists.cncf.io"
-
-RUN apk add --no-cache --update
-RUN apk add gcc musl-dev make bash git go
-ADD . /driverkit
-
-WORKDIR /driverkit
-RUN make build
-
 FROM docker.io/alpine:3.16
-COPY --from=builder /driverkit/_output/bin/driverkit /bin/driverkit
+
+ARG TARGETARCH
+
+COPY build-${TARGETARCH}/driverkit /bin/driverkit
 CMD ["/bin/driverkit"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area cmd

> /area pkg

> /area docs

> /area tests


**What this PR does / why we need it**:

This PR adds arm64 CI jobs.
Fixed tests on arm64 (same `buildmode=pie` that we already had to do for go build in #151).

Moreover, improved CI: x86 and arm64 build-test jobs will now store artifacts in the workspace,
and they are later retrieved by "images" job.
This way we are able to avoid the qemu build of driverkit for arm64 when running buildx.
Old CI took ~1h, new CI takes ~20m.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
