### PR TITLE
fix(ci): fixed push latest images target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,10 +82,8 @@ push/driverkit:
 
 .PHONY: push/latest
 push/latest:
-	$(DOCKER) tag $(IMAGE_NAME_BUILDER_COMMIT) $(IMAGE_NAME_BUILDER_LATEST)
-	$(DOCKER) push $(IMAGE_NAME_BUILDER_LATEST)
-	$(DOCKER) tag $(IMAGE_NAME_DRIVERKIT_COMMIT) $(IMAGE_NAME_DRIVERKIT_LATEST)
-	$(DOCKER) push $(IMAGE_NAME_DRIVERKIT_LATEST)
+	$(DOCKER) buildx build --push --platform $(ARCHS) -t "$(IMAGE_NAME_BUILDER_LATEST)" -f build/builder.Dockerfile .
+	$(DOCKER) buildx build --push --platform $(ARCHS) -t "$(IMAGE_NAME_DRIVERKIT_LATEST)" -f build/driverkit.Dockerfile .
 
 .PHONY: test
 test:


### PR DESCRIPTION
Signed-off-by: Federico Di Pierro <nierro92@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area cmd

> /area pkg

> /area docs

> /area tests


**What this PR does / why we need it**:

`docker buildx` in docker-container driver, does not create local tags for images. Therefore, we cannot just re-tag the "push/all" tagged images in the "push/latest" target.

We need to explicitly call `buildx` again. Note that the build is cached anyway.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
