### PR TITLE
fix(build): disable cgo.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,11 +49,11 @@ driverkit_docgen ?= _output/bin/docgen
 build: clean ${driverkit}
 
 ${driverkit}:
-	CGO_ENABLED=1 go build -v -buildmode=pie -ldflags '${LDFLAGS}' -tags '${GOTAGS}' -o $@ .
+	CGO_ENABLED=0 go build -v -buildmode=pie -ldflags '${LDFLAGS}' -tags '${GOTAGS}' -o $@ .
 
 .PHONY: release
 release: clean
-	CGO_ENABLED=1 LDFLAGS="${LDFLAGS}" GOTAGS="${GOTAGS}" $(GORELEASER) release
+	CGO_ENABLED=0 LDFLAGS="${LDFLAGS}" GOTAGS="${GOTAGS}" $(GORELEASER) release
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Signed-off-by: Federico Di Pierro <nierro92@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area cmd

> /area pkg

> /area docs

> /area tests


**What this PR does / why we need it**:

CGO was wrongly enabled, and it caused cross compilation with goreleaser to arm64 to fail: 
```
# runtime/cgo
gcc_arm64.S: Assembler messages:
gcc_arm64.S:28: Error: no such instruction: `stp x29,x30,[sp,'
gcc_arm64.S:32: Error: too many memory references for `mov'
...
```

Moreover, we now ship in our release page, really portable go binaries (that do not depend upon certaing specific glibc versions).

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
