### PR TITLE
More Ubuntu Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist/
 vendor/
 
 driverkit
+
+coverage.out

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ IMAGE_NAME_DRIVERKIT_REF := $(IMAGE_NAME_DRIVERKIT):$(GIT_REF)
 IMAGE_NAME_DRIVERKIT_COMMIT := $(IMAGE_NAME_DRIVERKIT):$(GIT_COMMIT)
 IMAGE_NAME_DRIVERKIT_LATEST := $(IMAGE_NAME_DRIVERKIT):latest
 
-LDFLAGS := -X github.com/falcosecurity/driverkit/pkg/version.buildTime=$(shell date +%s) -X github.com/falcosecurity/driverkit/pkg/version.gitCommit=${GIT_COMMIT} -X github.com/falcosecurity/driverkit/pkg/version.gitTag=$(if ${GIT_TAG},${GIT_TAG},v0.0.0) -X github.com/falcosecurity/driverkit/pkg/version.commitsFromGitTag=${COMMITS_FROM_GIT_TAG} -X github.com/falcosecurity/driverkit/pkg/driverbuilder.BuilderBaseImage=${IMAGE_NAME_BUILDER_COMMIT}
+LDFLAGS := -X github.com/falcosecurity/driverkit/pkg/version.buildTime=$(shell date +%s) -X github.com/falcosecurity/driverkit/pkg/version.gitCommit=${GIT_COMMIT} -X github.com/falcosecurity/driverkit/pkg/version.gitTag=$(if ${GIT_TAG},${GIT_TAG},v0.0.0) -X github.com/falcosecurity/driverkit/pkg/version.commitsFromGitTag=${COMMITS_FROM_GIT_TAG} -X github.com/falcosecurity/driverkit/pkg/driverbuilder.BuilderBaseImage=${IMAGE_NAME_BUILDER_LATEST}
 
 ARCHS := "arm64,amd64"
 

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ IMAGE_NAME_DRIVERKIT_REF := $(IMAGE_NAME_DRIVERKIT):$(GIT_REF)
 IMAGE_NAME_DRIVERKIT_COMMIT := $(IMAGE_NAME_DRIVERKIT):$(GIT_COMMIT)
 IMAGE_NAME_DRIVERKIT_LATEST := $(IMAGE_NAME_DRIVERKIT):latest
 
-LDFLAGS := -X github.com/falcosecurity/driverkit/pkg/version.buildTime=$(shell date +%s) -X github.com/falcosecurity/driverkit/pkg/version.gitCommit=${GIT_COMMIT} -X github.com/falcosecurity/driverkit/pkg/version.gitTag=$(if ${GIT_TAG},${GIT_TAG},v0.0.0) -X github.com/falcosecurity/driverkit/pkg/version.commitsFromGitTag=${COMMITS_FROM_GIT_TAG} -X github.com/falcosecurity/driverkit/pkg/driverbuilder.BuilderBaseImage=${IMAGE_NAME_BUILDER_LATEST}
+LDFLAGS := -X github.com/falcosecurity/driverkit/pkg/version.buildTime=$(shell date +%s) -X github.com/falcosecurity/driverkit/pkg/version.gitCommit=${GIT_COMMIT} -X github.com/falcosecurity/driverkit/pkg/version.gitTag=$(if ${GIT_TAG},${GIT_TAG},v0.0.0) -X github.com/falcosecurity/driverkit/pkg/version.commitsFromGitTag=${COMMITS_FROM_GIT_TAG} -X github.com/falcosecurity/driverkit/pkg/driverbuilder.BuilderBaseImage=${IMAGE_NAME_BUILDER_COMMIT}
 
 ARCHS := "arm64,amd64"
 

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ integration_test: $(test_configs)
 
 .PHONY: $(test_configs)
 $(test_configs): ${driverkit}
-	${driverkit} docker -c $@ --builderimage falcosecurity/driverkit-builder:latest -l debug --timeout 600
+	${driverkit} docker -c $@ --builderimage $(IMAGE_NAME_BUILDER_COMMIT) -l debug --timeout 600
 
 .PHONY: ${driverkit_docgen}
 ${driverkit_docgen}: ${PWD}/docgen

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ push/latest:
 .PHONY: test
 test:
 	go test -v -cover -race ./...
-	go test -v -buildmode=pie ./cmd
+	go test -v -cover -buildmode=pie ./cmd
 
 .PHONY: integration_test
 integration_test: $(test_configs)

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ integration_test: $(test_configs)
 
 .PHONY: $(test_configs)
 $(test_configs): ${driverkit}
-	${driverkit} docker -c $@ --builderimage $(IMAGE_NAME_BUILDER_COMMIT) -l debug --timeout 600
+	${driverkit} docker -c $@ --builderimage falcosecurity/driverkit-builder:latest -l debug --timeout 600
 
 .PHONY: ${driverkit_docgen}
 ${driverkit_docgen}: ${PWD}/docgen

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ push/latest:
 
 .PHONY: test
 test:
-	go test -v -race ./...
+	go test -v -cover -race ./...
 	go test -v -buildmode=pie ./cmd
 
 .PHONY: integration_test

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,34 +37,34 @@ func persistentValidateFunc(rootCommand *RootCmd, rootOpts *RootOptions) func(c 
 			"output-probe":  "output.probe",
 		}
 		rootCommand.c.Flags().VisitAll(func(f *pflag.Flag) {
-			if name := f.Name; !skip[name] {
-				if name == "kernelurls" {
-					// Slice types need special treatment when used as flags. If we call 'Set(name, value)',
-					// rather than replace, it appends. Since viper will already have the cli options set
-					// if supplied, we only need this step if rootCommand doesn't already have them e.g.
-					// not set on CLI so read from config.
-					if cli_urls, err := rootCommand.c.Flags().GetStringSlice(name); err == nil && len(cli_urls) != 0 {
-						return
-					}
-					value := viper.GetStringSlice(name)
-					if len(value) != 0 {
-						strValue := strings.Join(value, ",")
-						rootCommand.c.Flags().Set(name, strValue)
-					}
-				} else {
-					value := viper.GetString(name)
-					if value == "" {
-						// fallback to nested options in config file, if any
-						if nestedName, ok := nested[name]; ok {
-							value = viper.GetString(nestedName)
-						}
-					}
-					// set the value, if any, otherwise let the default
-					if value != "" {
-						rootCommand.c.Flags().Set(name, value)
-					}
-				}
-			}
+		    if name := f.Name; !skip[name] {
+                if name == "kernelurls" {
+                    // Slice types need special treatment when used as flags. If we call 'Set(name, value)',
+                    // rather than replace, it appends. Since viper will already have the cli options set
+                    // if supplied, we only need this step if rootCommand doesn't already have them e.g.
+                    // not set on CLI so read from config.
+                    if cli_urls, err := rootCommand.c.Flags().GetStringSlice(name); err == nil && len(cli_urls) != 0 {
+                       return
+                    }
+                    value := viper.GetStringSlice(name)
+                    if len(value) != 0 {
+                        strValue := strings.Join(value, ",")
+                        rootCommand.c.Flags().Set(name, strValue)
+                    }
+                } else {
+                    value := viper.GetString(name)
+                    if value == "" {
+                        // fallback to nested options in config file, if any
+                        if nestedName, ok := nested[name]; ok {
+                            value = viper.GetString(nestedName)
+                        }
+                    }
+                    // set the value, if any, otherwise let the default
+                    if value != "" {
+                        rootCommand.c.Flags().Set(name, value)
+                    }
+                }
+            }
 		})
 
 		// Avoid sensitive info into default values help line

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,34 +37,34 @@ func persistentValidateFunc(rootCommand *RootCmd, rootOpts *RootOptions) func(c 
 			"output-probe":  "output.probe",
 		}
 		rootCommand.c.Flags().VisitAll(func(f *pflag.Flag) {
-		    if name := f.Name; !skip[name] {
-                if name == "kernelurls" {
-                    // Slice types need special treatment when used as flags. If we call 'Set(name, value)',
-                    // rather than replace, it appends. Since viper will already have the cli options set
-                    // if supplied, we only need this step if rootCommand doesn't already have them e.g.
-                    // not set on CLI so read from config.
-                    if cli_urls, err := rootCommand.c.Flags().GetStringSlice(name); err == nil && len(cli_urls) != 0 {
-                       return
-                    }
-                    value := viper.GetStringSlice(name)
-                    if len(value) != 0 {
-                        strValue := strings.Join(value, ",")
-                        rootCommand.c.Flags().Set(name, strValue)
-                    }
-                } else {
-                    value := viper.GetString(name)
-                    if value == "" {
-                        // fallback to nested options in config file, if any
-                        if nestedName, ok := nested[name]; ok {
-                            value = viper.GetString(nestedName)
-                        }
-                    }
-                    // set the value, if any, otherwise let the default
-                    if value != "" {
-                        rootCommand.c.Flags().Set(name, value)
-                    }
-                }
-            }
+			if name := f.Name; !skip[name] {
+				if name == "kernelurls" {
+					// Slice types need special treatment when used as flags. If we call 'Set(name, value)',
+					// rather than replace, it appends. Since viper will already have the cli options set
+					// if supplied, we only need this step if rootCommand doesn't already have them e.g.
+					// not set on CLI so read from config.
+					if cli_urls, err := rootCommand.c.Flags().GetStringSlice(name); err == nil && len(cli_urls) != 0 {
+						return
+					}
+					value := viper.GetStringSlice(name)
+					if len(value) != 0 {
+						strValue := strings.Join(value, ",")
+						rootCommand.c.Flags().Set(name, strValue)
+					}
+				} else {
+					value := viper.GetString(name)
+					if value == "" {
+						// fallback to nested options in config file, if any
+						if nestedName, ok := nested[name]; ok {
+							value = viper.GetString(nestedName)
+						}
+					}
+					// set the value, if any, otherwise let the default
+					if value != "" {
+						rootCommand.c.Flags().Set(name, value)
+					}
+				}
+			}
 		})
 
 		// Avoid sensitive info into default values help line
@@ -128,7 +128,7 @@ func NewRootCmd() *RootCmd {
 	flags.StringVar(&rootOpts.Output.Probe, "output-probe", rootOpts.Output.Probe, "filepath where to save the resulting eBPF probe")
 	flags.StringVar(&rootOpts.Architecture, "architecture", runtime.GOARCH, "target architecture for the built driver")
 	flags.StringVar(&rootOpts.DriverVersion, "driverversion", rootOpts.DriverVersion, "driver version as a git commit hash or as a git tag")
-	flags.Uint16Var(&rootOpts.KernelVersion, "kernelversion", rootOpts.KernelVersion, "kernel version to build the module for, it's the numeric value after the hash when you execute 'uname -v'")
+	flags.StringVar(&rootOpts.KernelVersion, "kernelversion", rootOpts.KernelVersion, "kernel version to build the module for, it's the numeric value after the hash when you execute 'uname -v'")
 	flags.StringVar(&rootOpts.KernelRelease, "kernelrelease", rootOpts.KernelRelease, "kernel release to build the module for, it can be found by executing 'uname -v'")
 	flags.StringVarP(&rootOpts.Target, "target", "t", rootOpts.Target, "the system to target the build for")
 	flags.StringVar(&rootOpts.KernelConfigData, "kernelconfigdata", rootOpts.KernelConfigData, "base64 encoded kernel config data: in some systems it can be found under the /boot directory, in other it is gzip compressed under /proc")

--- a/cmd/root_options.go
+++ b/cmd/root_options.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/creasty/defaults"
 	"github.com/falcosecurity/driverkit/pkg/driverbuilder"
 	"github.com/falcosecurity/driverkit/pkg/driverbuilder/builder"
@@ -90,8 +91,8 @@ func (ro *RootOptions) Log() {
 	}
 	fields["arch"] = ro.Architecture
 	if len(ro.KernelUrls) > 0 {
-        fields["kernelurls"] = ro.KernelUrls
-    }
+		fields["kernelurls"] = ro.KernelUrls
+	}
 
 	logger.WithFields(fields).Debug("running with options")
 }
@@ -128,7 +129,7 @@ func RootOptionsLevelValidation(level validator.StructLevel) {
 		level.ReportError(opts.KernelConfigData, "kernelConfigData", "KernelConfigData", "required_kernelconfigdata_with_target_vanilla", "")
 	}
 
-	if opts.KernelVersion == 0 && (opts.Target == builder.TargetTypeUbuntuAWS.String() || opts.Target == builder.TargetTypeUbuntuGeneric.String()) {
+	if opts.KernelVersion == 0 && opts.Target == builder.TargetTypeUbuntu.String() {
 		level.ReportError(opts.KernelVersion, "kernelVersion", "KernelVersion", "required_kernelversion_with_target_ubuntu", "")
 	}
 

--- a/cmd/root_options.go
+++ b/cmd/root_options.go
@@ -21,7 +21,7 @@ type OutputOptions struct {
 type RootOptions struct {
 	Architecture     string   `validate:"required,oneof=amd64 arm64" name:"architecture"`
 	DriverVersion    string   `default:"master" validate:"eq=master|sha1|semver" name:"driver version"`
-	KernelVersion    string   `default:"1" validate:"required" name:"kernel version"`
+	KernelVersion    string   `default:"1" validate:"omitempty" name:"kernel version"`
 	ModuleDriverName string   `default:"falco" validate:"max=60" name:"kernel module driver name"`
 	ModuleDeviceName string   `default:"falco" validate:"excludes=/,max=255" name:"kernel module device name"`
 	KernelRelease    string   `validate:"required,ascii" name:"kernel release"`
@@ -135,6 +135,6 @@ func RootOptionsLevelValidation(level validator.StructLevel) {
 
 	// Target redhat requires a valid build image (has to be registered in order to download packages)
 	if opts.Target == builder.TargetTypeRedhat.String() && opts.BuilderImage == driverbuilder.BuilderBaseImage {
-	    level.ReportError(opts.BuilderImage, "builderimage", "builderimage", "required_builderimage_with_target_redhat", "")
+		level.ReportError(opts.BuilderImage, "builderimage", "builderimage", "required_builderimage_with_target_redhat", "")
 	}
 }

--- a/cmd/root_options.go
+++ b/cmd/root_options.go
@@ -129,7 +129,8 @@ func RootOptionsLevelValidation(level validator.StructLevel) {
 		level.ReportError(opts.KernelConfigData, "kernelConfigData", "KernelConfigData", "required_kernelconfigdata_with_target_vanilla", "")
 	}
 
-	if opts.KernelVersion == "" && opts.Target == builder.TargetTypeUbuntu.String() {
+	// UbuntuAWS and UbuntuGeneric should be deprecated in future in favor of just Ubuntu
+	if opts.KernelVersion == "" && (opts.Target == builder.TargetTypeUbuntu.String() || opts.Target == builder.TargetTypeUbuntuAWS.String() || opts.Target == builder.TargetTypeUbuntuGeneric.String()) {
 		level.ReportError(opts.KernelVersion, "kernelVersion", "KernelVersion", "required_kernelversion_with_target_ubuntu", "")
 	}
 

--- a/cmd/root_options.go
+++ b/cmd/root_options.go
@@ -21,7 +21,7 @@ type OutputOptions struct {
 type RootOptions struct {
 	Architecture     string   `validate:"required,oneof=amd64 arm64" name:"architecture"`
 	DriverVersion    string   `default:"master" validate:"eq=master|sha1|semver" name:"driver version"`
-	KernelVersion    uint16   `default:"1" validate:"omitempty,number" name:"kernel version"`
+	KernelVersion    string   `default:"1" validate:"required" name:"kernel version"`
 	ModuleDriverName string   `default:"falco" validate:"max=60" name:"kernel module driver name"`
 	ModuleDeviceName string   `default:"falco" validate:"excludes=/,max=255" name:"kernel module device name"`
 	KernelRelease    string   `validate:"required,ascii" name:"kernel release"`
@@ -83,7 +83,7 @@ func (ro *RootOptions) Log() {
 	if ro.KernelRelease != "" {
 		fields["kernelrelease"] = ro.KernelRelease
 	}
-	if ro.KernelVersion > 0 {
+	if ro.KernelVersion != "" {
 		fields["kernelversion"] = ro.KernelVersion
 	}
 	if ro.Target != "" {
@@ -129,7 +129,7 @@ func RootOptionsLevelValidation(level validator.StructLevel) {
 		level.ReportError(opts.KernelConfigData, "kernelConfigData", "KernelConfigData", "required_kernelconfigdata_with_target_vanilla", "")
 	}
 
-	if opts.KernelVersion == 0 && opts.Target == builder.TargetTypeUbuntu.String() {
+	if opts.KernelVersion == "" && opts.Target == builder.TargetTypeUbuntu.String() {
 		level.ReportError(opts.KernelVersion, "kernelVersion", "KernelVersion", "required_kernelversion_with_target_ubuntu", "")
 	}
 

--- a/cmd/testdata/autohelp.txt
+++ b/cmd/testdata/autohelp.txt
@@ -21,7 +21,7 @@ Flags:
       --kernelconfigdata string   base64 encoded kernel config data: in some systems it can be found under the /boot directory, in other it is gzip compressed under /proc
       --kernelrelease string      kernel release to build the module for, it can be found by executing 'uname -v'
       --kernelurls strings        list of kernel header urls (e.g. --kernelurls <URL1> --kernelurls <URL2> --kernelurls "<URL3>,<URL4>")
-      --kernelversion uint16      kernel version to build the module for, it's the numeric value after the hash when you execute 'uname -v' (default 1)
+      --kernelversion string      kernel version to build the module for, it's the numeric value after the hash when you execute 'uname -v' (default "1")
   -l, --loglevel string           log level (default "info")
       --moduledevicename string   kernel module device name (the default is falco, so the device will be under /dev/falco*) (default "falco")
       --moduledrivername string   kernel module driver name, i.e. the name you see when you check installed modules via lsmod (default "falco")

--- a/cmd/testdata/completion-targets.txt
+++ b/cmd/testdata/completion-targets.txt
@@ -7,6 +7,7 @@ debian
 flatcar
 redhat
 rocky
+ubuntu
 ubuntu-aws
 ubuntu-generic
 vanilla

--- a/cmd/testdata/docker-target-redhat-validation-error-debug.txt
+++ b/cmd/testdata/docker-target-redhat-validation-error-debug.txt
@@ -14,7 +14,7 @@ Flags:
       --kernelconfigdata string   base64 encoded kernel config data: in some systems it can be found under the /boot directory, in other it is gzip compressed under /proc
       --kernelrelease string      kernel release to build the module for, it can be found by executing 'uname -v'
       --kernelurls strings        list of kernel header urls (e.g. --kernelurls <URL1> --kernelurls <URL2> --kernelurls "<URL3>,<URL4>")
-      --kernelversion uint16      kernel version to build the module for, it's the numeric value after the hash when you execute 'uname -v' (default 1)
+      --kernelversion string      kernel version to build the module for, it's the numeric value after the hash when you execute 'uname -v' (default "1")
   -l, --loglevel string           log level (default "info")
       --moduledevicename string   kernel module device name (the default is falco, so the device will be under /dev/falco*) (default "falco")
       --moduledrivername string   kernel module driver name, i.e. the name you see when you check installed modules via lsmod (default "falco")

--- a/cmd/testdata/dockernoopts.txt
+++ b/cmd/testdata/dockernoopts.txt
@@ -16,7 +16,7 @@ Flags:
       --kernelconfigdata string   base64 encoded kernel config data: in some systems it can be found under the /boot directory, in other it is gzip compressed under /proc
       --kernelrelease string      kernel release to build the module for, it can be found by executing 'uname -v'
       --kernelurls strings        list of kernel header urls (e.g. --kernelurls <URL1> --kernelurls <URL2> --kernelurls "<URL3>,<URL4>")
-      --kernelversion uint16      kernel version to build the module for, it's the numeric value after the hash when you execute 'uname -v' (default 1)
+      --kernelversion string      kernel version to build the module for, it's the numeric value after the hash when you execute 'uname -v' (default "1")
   -l, --loglevel string           log level (default "info")
       --moduledevicename string   kernel module device name (the default is falco, so the device will be under /dev/falco*) (default "falco")
       --moduledrivername string   kernel module driver name, i.e. the name you see when you check installed modules via lsmod (default "falco")

--- a/cmd/testdata/help-flag.txt
+++ b/cmd/testdata/help-flag.txt
@@ -20,7 +20,7 @@ Flags:
       --kernelconfigdata string   base64 encoded kernel config data: in some systems it can be found under the /boot directory, in other it is gzip compressed under /proc
       --kernelrelease string      kernel release to build the module for, it can be found by executing 'uname -v'
       --kernelurls strings        list of kernel header urls (e.g. --kernelurls <URL1> --kernelurls <URL2> --kernelurls "<URL3>,<URL4>")
-      --kernelversion uint16      kernel version to build the module for, it's the numeric value after the hash when you execute 'uname -v' (default 1)
+      --kernelversion string      kernel version to build the module for, it's the numeric value after the hash when you execute 'uname -v' (default "1")
   -l, --loglevel string           log level (default "info")
       --moduledevicename string   kernel module device name (the default is falco, so the device will be under /dev/falco*) (default "falco")
       --moduledrivername string   kernel module driver name, i.e. the name you see when you check installed modules via lsmod (default "falco")

--- a/cmd/testdata/help.txt
+++ b/cmd/testdata/help.txt
@@ -20,7 +20,7 @@ Flags:
       --kernelconfigdata string   base64 encoded kernel config data: in some systems it can be found under the /boot directory, in other it is gzip compressed under /proc
       --kernelrelease string      kernel release to build the module for, it can be found by executing 'uname -v'
       --kernelurls strings        list of kernel header urls (e.g. --kernelurls <URL1> --kernelurls <URL2> --kernelurls "<URL3>,<URL4>")
-      --kernelversion uint16      kernel version to build the module for, it's the numeric value after the hash when you execute 'uname -v' (default 1)
+      --kernelversion string      kernel version to build the module for, it's the numeric value after the hash when you execute 'uname -v' (default "1")
   -l, --loglevel string           log level (default "info")
       --moduledevicename string   kernel module device name (the default is falco, so the device will be under /dev/falco*) (default "falco")
       --moduledrivername string   kernel module driver name, i.e. the name you see when you check installed modules via lsmod (default "falco")

--- a/cmd/testdata/invalid-proxyconfig.txt
+++ b/cmd/testdata/invalid-proxyconfig.txt
@@ -20,7 +20,7 @@ Flags:
       --kernelconfigdata string   base64 encoded kernel config data: in some systems it can be found under the /boot directory, in other it is gzip compressed under /proc
       --kernelrelease string      kernel release to build the module for, it can be found by executing 'uname -v'
       --kernelurls strings        list of kernel header urls (e.g. --kernelurls <URL1> --kernelurls <URL2> --kernelurls "<URL3>,<URL4>")
-      --kernelversion uint16      kernel version to build the module for, it's the numeric value after the hash when you execute 'uname -v' (default 1)
+      --kernelversion string      kernel version to build the module for, it's the numeric value after the hash when you execute 'uname -v' (default "1")
   -l, --loglevel string           log level (default "info")
       --moduledevicename string   kernel module device name (the default is falco, so the device will be under /dev/falco*) (default "falco")
       --moduledrivername string   kernel module driver name, i.e. the name you see when you check installed modules via lsmod (default "falco")

--- a/cmd/testdata/non-existent-processor.txt
+++ b/cmd/testdata/non-existent-processor.txt
@@ -19,7 +19,7 @@ Flags:
       --kernelconfigdata string   base64 encoded kernel config data: in some systems it can be found under the /boot directory, in other it is gzip compressed under /proc
       --kernelrelease string      kernel release to build the module for, it can be found by executing 'uname -v'
       --kernelurls strings        list of kernel header urls (e.g. --kernelurls <URL1> --kernelurls <URL2> --kernelurls "<URL3>,<URL4>")
-      --kernelversion uint16      kernel version to build the module for, it's the numeric value after the hash when you execute 'uname -v' (default 1)
+      --kernelversion string      kernel version to build the module for, it's the numeric value after the hash when you execute 'uname -v' (default "1")
   -l, --loglevel string           log level (default "info")
       --moduledevicename string   kernel module device name (the default is falco, so the device will be under /dev/falco*) (default "falco")
       --moduledrivername string   kernel module driver name, i.e. the name you see when you check installed modules via lsmod (default "falco")

--- a/pkg/driverbuilder/builder/archlinux.go
+++ b/pkg/driverbuilder/builder/archlinux.go
@@ -61,7 +61,7 @@ func (c archlinux) Script(cfg Config, kr kernelrelease.KernelRelease) (string, e
 	return buf.String(), nil
 }
 
-func fetchArchlinuxKernelURLS(kr kernelrelease.KernelRelease, kv uint16) []string {
+func fetchArchlinuxKernelURLS(kr kernelrelease.KernelRelease, kv string) []string {
 	urls := []string{}
 
 	if kr.Architecture == "amd64" {

--- a/pkg/driverbuilder/builder/archlinux.go
+++ b/pkg/driverbuilder/builder/archlinux.go
@@ -66,14 +66,14 @@ func fetchArchlinuxKernelURLS(kr kernelrelease.KernelRelease, kv string) []strin
 
 	if kr.Architecture == "amd64" {
 		urls = append(urls, fmt.Sprintf(
-			"https://archive.archlinux.org/packages/l/linux-headers/linux-headers-%s.%s-%d-%s.pkg.tar.xz",
+			"https://archive.archlinux.org/packages/l/linux-headers/linux-headers-%s.%s-%s-%s.pkg.tar.xz",
 			kr.Fullversion,
 			kr.Extraversion,
 			kv,
 			kr.Architecture.ToNonDeb()))
 	} else {
 		urls = append(urls, fmt.Sprintf(
-			"http://tardis.tiny-vps.com/aarm/packages/l/linux-%s-headers/linux-%s-headers-%s-%d-%s.pkg.tar.xz",
+			"http://tardis.tiny-vps.com/aarm/packages/l/linux-%s-headers/linux-%s-headers-%s-%s-%s.pkg.tar.xz",
 			kr.Architecture.ToNonDeb(),
 			kr.Architecture.ToNonDeb(),
 			kr.Fullversion,

--- a/pkg/driverbuilder/builder/build.go
+++ b/pkg/driverbuilder/builder/build.go
@@ -7,7 +7,7 @@ type Build struct {
 	TargetType         Type
 	KernelConfigData   string
 	KernelRelease      string
-	KernelVersion      uint16
+	KernelVersion      string
 	DriverVersion      string
 	Architecture       string
 	ModuleFilePath     string

--- a/pkg/driverbuilder/builder/templates/ubuntu.sh
+++ b/pkg/driverbuilder/builder/templates/ubuntu.sh
@@ -18,7 +18,7 @@ cd /tmp/kernel-download
 {{range $url := .KernelDownloadURLS}}
 curl --silent -o kernel.deb -SL {{ $url }}
 ar x kernel.deb
-tar -xf data.tar.*
+tar -xvf data.tar.*
 {{end}}
 
 cd /tmp/kernel-download/usr/src/

--- a/pkg/driverbuilder/builder/templates/ubuntu.sh
+++ b/pkg/driverbuilder/builder/templates/ubuntu.sh
@@ -18,7 +18,7 @@ cd /tmp/kernel-download
 {{range $url := .KernelDownloadURLS}}
 curl --silent -o kernel.deb -SL {{ $url }}
 ar x kernel.deb
-tar -xvf data.tar.*
+tar -xf data.tar.*
 {{end}}
 
 cd /tmp/kernel-download/usr/src/

--- a/pkg/driverbuilder/builder/ubuntu.go
+++ b/pkg/driverbuilder/builder/ubuntu.go
@@ -74,7 +74,7 @@ func (v ubuntu) Script(c Config, kr kernelrelease.KernelRelease) (string, error)
 		ModuleDownloadURL:    moduleDownloadURL(c),
 		KernelDownloadURLS:   urls,
 		KernelLocalVersion:   kr.FullExtraversion,
-		KernelHeadersPattern: "linux*headers*",
+		KernelHeadersPattern: "linux-headers*",
 		ModuleDriverName:     c.Build.ModuleDriverName,
 		ModuleFullPath:       ModuleFullPath,
 		BuildModule:          len(c.Build.ModuleFilePath) > 0,
@@ -202,6 +202,10 @@ func fetchUbuntuKernelURL(baseURL string, kr kernelrelease.KernelRelease, kernel
 			)
 		}
 	}
+
+	// fmt.Println()
+	// fmt.Println(packageFullURLs)
+	// fmt.Println()
 
 	return packageFullURLs, nil
 }

--- a/pkg/driverbuilder/builder/ubuntu.go
+++ b/pkg/driverbuilder/builder/ubuntu.go
@@ -246,7 +246,7 @@ func parseUbuntuExtraVersion(extraversion string) (string, string) {
 	if strings.Contains(extraversion, "-") {
 		split := strings.Split(extraversion, "-")
 		extraNumber := split[0]
-		flavor := split[1]
+		flavor := strings.Join(split[1:], "-") // assume the back half of the split is the flavor, rejoin on '-'
 		return extraNumber, flavor
 	}
 

--- a/pkg/driverbuilder/builder/ubuntu.go
+++ b/pkg/driverbuilder/builder/ubuntu.go
@@ -38,7 +38,7 @@ type ubuntuTemplateData struct {
 }
 
 // Script compiles the script to build the kernel module and/or the eBPF probe.
-func (v ubuntu) Script(c Config) (string, error) {
+func (v ubuntu) Script(c Config, kr kernelrelease.KernelRelease) (string, error) {
 
 	t := template.New(string(TargetTypeUbuntu))
 
@@ -47,8 +47,7 @@ func (v ubuntu) Script(c Config) (string, error) {
 		return "", err
 	}
 
-	// read in the build config
-	kr := kernelReleaseFromBuildConfig(c.Build)
+	// debugging
 	fmt.Printf("%+v\n", kr)
 
 	var urls []string

--- a/pkg/driverbuilder/builder/ubuntu.go
+++ b/pkg/driverbuilder/builder/ubuntu.go
@@ -64,7 +64,7 @@ func (v ubuntu) Script(c Config, kr kernelrelease.KernelRelease) (string, error)
 
 	td := ubuntuTemplateData{
 		DriverBuildDir:       DriverDirectory,
-		ModuleDownloadURL:    fmt.Sprintf("%s/%s.tar.gz", c.DownloadBaseURL, c.Build.DriverVersion),
+		ModuleDownloadURL:    moduleDownloadURL(c),
 		KernelDownloadURLS:   urls,
 		KernelLocalVersion:   kr.FullExtraversion,
 		KernelHeadersPattern: "linux*headers*",

--- a/pkg/driverbuilder/builder/ubuntu.go
+++ b/pkg/driverbuilder/builder/ubuntu.go
@@ -223,7 +223,9 @@ func fetchUbuntuKernelURL(baseURL string, kr kernelrelease.KernelRelease, kernel
 func parseUbuntuExtraVersion(extraversion string) (string, string, error) {
 	if strings.Contains(extraversion, "-") {
 		split := strings.Split(extraversion, "-")
-		return split[0], split[1], nil
+		extraNumber := split[0]
+		flavor := split[1]
+		return extraNumber, flavor, nil
 	}
 
 	// let the user know the kernelrelease may be formatted incorrectly

--- a/pkg/driverbuilder/builder/ubuntu.go
+++ b/pkg/driverbuilder/builder/ubuntu.go
@@ -74,7 +74,7 @@ func (v ubuntu) Script(c Config, kr kernelrelease.KernelRelease) (string, error)
 		ModuleDownloadURL:    moduleDownloadURL(c),
 		KernelDownloadURLS:   urls,
 		KernelLocalVersion:   kr.FullExtraversion,
-		KernelHeadersPattern: "linux-headers*",
+		KernelHeadersPattern: fmt.Sprintf("linux-headers*%s", extractUbuntuFlavor(kr.Extraversion)),
 		ModuleDriverName:     c.Build.ModuleDriverName,
 		ModuleFullPath:       ModuleFullPath,
 		BuildModule:          len(c.Build.ModuleFilePath) > 0,

--- a/pkg/driverbuilder/builder/ubuntu.go
+++ b/pkg/driverbuilder/builder/ubuntu.go
@@ -10,6 +10,9 @@ import (
 	"github.com/falcosecurity/driverkit/pkg/kernelrelease"
 )
 
+//go:embed templates/ubuntu.sh
+var ubuntuTemplate string
+
 // TargetTypeUbuntu identifies the Ubuntu target.
 const TargetTypeUbuntu Type = "ubuntu"
 
@@ -232,66 +235,3 @@ func ubuntuGCCVersionFromKernelRelease(kr kernelrelease.KernelRelease) string {
 	}
 	return "8"
 }
-
-const ubuntuTemplate = `
-#!/bin/bash
-set -xeuo pipefail
-
-rm -Rf {{ .DriverBuildDir }}
-mkdir {{ .DriverBuildDir }}
-rm -Rf /tmp/module-download
-mkdir -p /tmp/module-download
-
-curl --silent -SL {{ .ModuleDownloadURL }} | tar -xzf - -C /tmp/module-download
-mv /tmp/module-download/*/driver/* {{ .DriverBuildDir }}
-
-cp /driverkit/module-Makefile {{ .DriverBuildDir }}/Makefile
-bash /driverkit/fill-driver-config.sh {{ .DriverBuildDir }}
-
-# Fetch the kernel
-mkdir /tmp/kernel-download
-cd /tmp/kernel-download
-{{range $url := .KernelDownloadURLS}}
-curl --silent -o kernel.deb -SL {{ $url }}
-ar x kernel.deb
-tar -xvf data.tar.*
-{{end}}
-ls -la /tmp/kernel-download
-
-cd /tmp/kernel-download/usr/src/
-sourcedir=$(find . -type d -name "{{ .KernelHeadersPattern }}" | head -n 1 | xargs readlink -f)
-
-ls -la $sourcedir
-
-# Change current gcc
-ln -sf /usr/bin/gcc-{{ .GCCVersion }} /usr/bin/gcc
-
-{{ if .BuildModule }}
-# Build the module
-cd {{ .DriverBuildDir }}
-make KERNELDIR=$sourcedir
-mv {{ .ModuleDriverName }}.ko {{ .ModuleFullPath }}
-strip -g {{ .ModuleFullPath }}
-# Print results
-modinfo {{ .ModuleFullPath }}
-{{ end }}
-
-{{ if .BuildProbe }}
-# Build the eBPF probe
-cd {{ .DriverBuildDir }}/bpf
-if [[ -x /usr/bin/llc ]]; then
-	LLC_BIN=/usr/bin/llc
-else
-	LLC_BIN=/usr/bin/llc-7
-fi
-
-if [[ -x /usr/bin/clang ]]; then
-	CLANG_BIN=/usr/bin/clang
-else
-	CLANG_BIN=/usr/bin/clang-7
-fi
-
-make LLC=$LLC_BIN CLANG=$CLANG_BIN CC=/usr/bin/gcc-8 KERNELDIR=$sourcedir
-ls -l probe.o
-{{ end }}
-`

--- a/pkg/driverbuilder/builder/ubuntu.go
+++ b/pkg/driverbuilder/builder/ubuntu.go
@@ -265,7 +265,7 @@ func ubuntuGCCVersionFromKernelRelease(kr kernelrelease.KernelRelease) string {
 		}
 	case 5:
 		switch {
-		case kr.PatchLevel >= 19:
+		case kr.PatchLevel >= 18:
 			return "11"
 		case kr.PatchLevel >= 11:
 			return "10"

--- a/pkg/driverbuilder/builder/ubuntu.go
+++ b/pkg/driverbuilder/builder/ubuntu.go
@@ -145,7 +145,7 @@ func fetchUbuntuKernelURL(baseURL string, kr kernelrelease.KernelRelease, kernel
 	}
 
 	// piece together all possible naming patterns for packages
-	// in general, there should be 2: an arch-specific package and an _all package
+	// 2 urls should resolve: an _{arch}.deb package and an _all.deb package
 	packageNamePatterns := []string{
 		fmt.Sprintf(
 			"linux-headers-%s%s_%s-%s.%s_%s_all.deb",
@@ -188,12 +188,7 @@ func fetchUbuntuKernelURL(baseURL string, kr kernelrelease.KernelRelease, kernel
 		}
 	}
 
-	// testing
-	fmt.Println(packageFullURLs)
-	// os.Exit(1)
-
 	return packageFullURLs, nil
-
 }
 
 func extractExtraNumber(extraversion string) string {

--- a/pkg/driverbuilder/builder/ubuntu.go
+++ b/pkg/driverbuilder/builder/ubuntu.go
@@ -10,11 +10,19 @@ import (
 	"github.com/falcosecurity/driverkit/pkg/kernelrelease"
 )
 
-// TargetTypeUbuntuGeneric identifies the Ubuntu target.
+// TargetTypeUbuntu identifies the Ubuntu target.
 const TargetTypeUbuntu Type = "ubuntu"
+
+// backwards compatibility
+const TargetTypeUbuntuGeneric Type = "ubuntu-generic"
+const TargetTypeUbuntuAWS Type = "ubuntu-aws"
 
 func init() {
 	BuilderByTarget[TargetTypeUbuntu] = &ubuntu{}
+
+	// backwards compatibility
+	BuilderByTarget[TargetTypeUbuntuGeneric] = &ubuntu{}
+	BuilderByTarget[TargetTypeUbuntuAWS] = &ubuntu{}
 }
 
 // ubuntu is a driverkit target.

--- a/pkg/driverbuilder/builder/ubuntu.go
+++ b/pkg/driverbuilder/builder/ubuntu.go
@@ -207,7 +207,26 @@ func fetchUbuntuKernelURL(baseURL string, kr kernelrelease.KernelRelease, kernel
 		}
 	}
 
-	return packageFullURLs, nil
+	// return out the deduplicated url list
+	return deduplicateURLs(packageFullURLs), nil
+}
+
+// deduplicate the array of URLs to ensure we are
+// only get unique resolving URLs for packages
+func deduplicateURLs(urls []string) []string {
+	keys := make(map[string]bool)
+	dedupURLs := []string{}
+
+	// loop over the URL list
+	// set a flag for new URLs in list, add to dedup list
+	// do nothing if URL is duplicate
+	for _, url := range urls {
+		if _, value := keys[url]; !value {
+			keys[url] = true
+			dedupURLs = append(dedupURLs, url)
+		}
+	}
+	return dedupURLs
 }
 
 // parse the extraversion from the kernelrelease to retrieve the extraNumber and flavor

--- a/pkg/driverbuilder/builder/ubuntu.go
+++ b/pkg/driverbuilder/builder/ubuntu.go
@@ -76,9 +76,9 @@ func (v ubuntu) Script(c Config, kr kernelrelease.KernelRelease) (string, error)
 	// Example: http://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-hwe/linux-headers-4.18.0-24-generic_4.18.0-24.25~18.04.1_amd64.deb
 	headersPattern := ""
 	if flavor == "hwe" {
-		headersPattern = "linux-headers*generic"
+		headersPattern = "linux-headers*generic*"
 	} else {
-		headersPattern = fmt.Sprintf("linux-headers*%s", flavor)
+		headersPattern = fmt.Sprintf("linux-headers*%s*", flavor)
 	}
 
 	td := ubuntuTemplateData{
@@ -246,7 +246,9 @@ func parseUbuntuExtraVersion(extraversion string) (string, string) {
 	if strings.Contains(extraversion, "-") {
 		split := strings.Split(extraversion, "-")
 		extraNumber := split[0]
-		flavor := strings.Join(split[1:], "-") // assume the back half of the split is the flavor, rejoin on '-'
+		// some flavors may be more than one word, ex: "intel-iotg"
+		// but getting just the first word is enough
+		flavor := split[1]
 		return extraNumber, flavor
 	}
 

--- a/pkg/driverbuilder/builder/ubuntu.go
+++ b/pkg/driverbuilder/builder/ubuntu.go
@@ -62,8 +62,7 @@ func (v ubuntu) Script(c Config, kr kernelrelease.KernelRelease) (string, error)
 	if err != nil {
 		return "", err
 	}
-	// if no results
-	if len(urls) == 0 {
+	if len(urls) < 2 {
 		return "", fmt.Errorf("specific kernel headers not found")
 	}
 
@@ -174,6 +173,15 @@ func fetchUbuntuKernelURL(baseURL string, kr kernelrelease.KernelRelease, kernel
 			kr.Fullversion,
 			firstExtra,
 			kernelVersion,
+		),
+		fmt.Sprintf(
+			"linux-headers-%s%s_%s-%s.%s_%s.deb",
+			kr.Fullversion,
+			kr.FullExtraversion,
+			kr.Fullversion,
+			firstExtra,
+			kernelVersion,
+			kr.Architecture.String(),
 		),
 	}
 

--- a/pkg/driverbuilder/builder/ubuntu.go
+++ b/pkg/driverbuilder/builder/ubuntu.go
@@ -72,12 +72,21 @@ func (v ubuntu) Script(c Config, kr kernelrelease.KernelRelease) (string, error)
 	// parse the flavor out of the kernelrelease extraversion
 	_, flavor := parseUbuntuExtraVersion(kr.Extraversion)
 
+	// handle hwe kernels, which resolve to "generic" urls under /linux-hwe
+	// Example: http://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-hwe/linux-headers-4.18.0-24-generic_4.18.0-24.25~18.04.1_amd64.deb
+	headersPattern := ""
+	if flavor == "hwe" {
+		headersPattern = "linux-headers*generic"
+	} else {
+		headersPattern = fmt.Sprintf("linux-headers*%s", flavor)
+	}
+
 	td := ubuntuTemplateData{
 		DriverBuildDir:       DriverDirectory,
 		ModuleDownloadURL:    moduleDownloadURL(c),
 		KernelDownloadURLS:   urls,
 		KernelLocalVersion:   kr.FullExtraversion,
-		KernelHeadersPattern: fmt.Sprintf("linux-headers*%s", flavor),
+		KernelHeadersPattern: headersPattern,
 		ModuleDriverName:     c.Build.ModuleDriverName,
 		ModuleFullPath:       ModuleFullPath,
 		BuildModule:          len(c.Build.ModuleFilePath) > 0,

--- a/pkg/driverbuilder/builder/ubuntu.go
+++ b/pkg/driverbuilder/builder/ubuntu.go
@@ -115,8 +115,7 @@ func ubuntuHeadersURLFromRelease(kr kernelrelease.KernelRelease, kv string) ([]s
 		}
 		// try resolving the URLs
 		urls, err := getResolvingURLs(possibleURLs)
-		fmt.Println(urls)
-		// there should be 2 urls returned - the _all package and the arch-specific package
+		// there should be 2 urls returned - the _all.deb package and the _{arch}.deb package
 		if err == nil && len(urls) == 2 {
 			return urls, err
 		}

--- a/pkg/driverbuilder/builder/ubuntu.go
+++ b/pkg/driverbuilder/builder/ubuntu.go
@@ -131,7 +131,7 @@ func fetchUbuntuKernelURL(baseURL string, kr kernelrelease.KernelRelease, kernel
 	ubuntuFlavor := extractUbuntuFlavor(kr.Extraversion)
 
 	// piece together possible subdirs on Ubuntu base URLs for a given flavor
-	// these include the base (such as 'linux-azure') and the base + version/path ('linux-azure-5.15')
+	// these include the base (such as 'linux-azure') and the base + version/patch ('linux-azure-5.15')
 	// examples:
 	// 		https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux
 	// 		https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-aws

--- a/pkg/driverbuilder/builder/ubuntu_test.go
+++ b/pkg/driverbuilder/builder/ubuntu_test.go
@@ -1,0 +1,333 @@
+package builder
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/falcosecurity/driverkit/pkg/kernelrelease"
+)
+
+var tests = []struct {
+	config        kernelrelease.KernelRelease
+	kernelversion string
+	expected      struct {
+		headersURLs []string
+		urls        []string
+		gccVersion  string
+		firstExtra  string
+		flavor      string
+		err         error
+	}
+}{
+	{
+		config: kernelrelease.KernelRelease{
+			Fullversion:      "4.15.0",
+			Version:          4,
+			PatchLevel:       15,
+			Sublevel:         0,
+			Extraversion:     "188",
+			FullExtraversion: "-188",
+			Architecture:     "amd64",
+		},
+		kernelversion: "199",
+		expected: struct {
+			headersURLs []string
+			urls        []string
+			gccVersion  string
+			firstExtra  string
+			flavor      string
+			err         error
+		}{
+			headersURLs: []string{},
+			urls:        []string{"https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-4.15.0-188_4.15.0-188.199_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-4.15.0-188-generic_4.15.0-188.199_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-generic-headers-4.15.0-188_4.15.0-188.199_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-4.15.0-188_4.15.0-188.199_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-generic/linux-headers-4.15.0-188_4.15.0-188.199_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-generic/linux-headers-4.15.0-188-generic_4.15.0-188.199_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-generic/linux-generic-headers-4.15.0-188_4.15.0-188.199_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-generic/linux-headers-4.15.0-188_4.15.0-188.199_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-generic-4.15/linux-headers-4.15.0-188_4.15.0-188.199_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-generic-4.15/linux-headers-4.15.0-188-generic_4.15.0-188.199_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-generic-4.15/linux-generic-headers-4.15.0-188_4.15.0-188.199_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-generic-4.15/linux-headers-4.15.0-188_4.15.0-188.199_amd64.deb"},
+			gccVersion:  "8",
+			firstExtra:  "188",
+			flavor:      "generic",
+			err:         fmt.Errorf("kernel headers not found"),
+		},
+	},
+	{
+		config: kernelrelease.KernelRelease{
+			Fullversion:      "4.15.0",
+			Version:          4,
+			PatchLevel:       15,
+			Sublevel:         0,
+			Extraversion:     "1129-aws",
+			FullExtraversion: "-1129-aws",
+			Architecture:     "arm64",
+		},
+		kernelversion: "138",
+		expected: struct {
+			headersURLs []string
+			urls        []string
+			gccVersion  string
+			firstExtra  string
+			flavor      string
+			err         error
+		}{
+			headersURLs: []string{"http://ports.ubuntu.com/ubuntu-ports/pool/main/l/linux-aws/linux-headers-4.15.0-1129-aws_4.15.0-1129.138_arm64.deb", "http://ports.ubuntu.com/ubuntu-ports/pool/main/l/linux-aws/linux-aws-headers-4.15.0-1129_4.15.0-1129.138_all.deb"},
+			urls:        []string{"http://ports.ubuntu.com/ubuntu-ports/pool/main/l/linux/linux-headers-4.15.0-1129-aws_4.15.0-1129.138_arm64_all.deb", "http://ports.ubuntu.com/ubuntu-ports/pool/main/l/linux/linux-headers-4.15.0-1129-aws_4.15.0-1129.138_arm64.deb", "http://ports.ubuntu.com/ubuntu-ports/pool/main/l/linux/linux-aws-headers-4.15.0-1129_4.15.0-1129.138_all.deb", "http://ports.ubuntu.com/ubuntu-ports/pool/main/l/linux-aws/linux-headers-4.15.0-1129-aws_4.15.0-1129.138_arm64_all.deb", "http://ports.ubuntu.com/ubuntu-ports/pool/main/l/linux-aws/linux-headers-4.15.0-1129-aws_4.15.0-1129.138_arm64.deb", "http://ports.ubuntu.com/ubuntu-ports/pool/main/l/linux-aws/linux-aws-headers-4.15.0-1129_4.15.0-1129.138_all.deb", "http://ports.ubuntu.com/ubuntu-ports/pool/main/l/linux-aws-4.15/linux-headers-4.15.0-1129-aws_4.15.0-1129.138_arm64_all.deb", "http://ports.ubuntu.com/ubuntu-ports/pool/main/l/linux-aws-4.15/linux-headers-4.15.0-1129-aws_4.15.0-1129.138_arm64.deb", "http://ports.ubuntu.com/ubuntu-ports/pool/main/l/linux-aws-4.15/linux-aws-headers-4.15.0-1129_4.15.0-1129.138_all.deb"},
+			gccVersion:  "8",
+			firstExtra:  "1129",
+			flavor:      "aws",
+			err:         nil,
+		},
+	},
+	{
+		config: kernelrelease.KernelRelease{
+			Fullversion:      "5.15.0",
+			Version:          5,
+			PatchLevel:       15,
+			Sublevel:         0,
+			Extraversion:     "1004-intel-iotg",
+			FullExtraversion: "-1004-intel-iotg",
+			Architecture:     "amd64",
+		},
+		kernelversion: "6",
+		expected: struct {
+			headersURLs []string
+			urls        []string
+			gccVersion  string
+			firstExtra  string
+			flavor      string
+			err         error
+		}{
+			headersURLs: []string{"https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-intel-iotg/linux-headers-5.15.0-1004-intel-iotg_5.15.0-1004.6_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-intel-iotg/linux-intel-iotg-headers-5.15.0-1004_5.15.0-1004.6_all.deb"},
+			urls:        []string{"https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-5.15.0-1004-intel-iotg_5.15.0-1004.6_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-5.15.0-1004-intel-iotg_5.15.0-1004.6_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-intel-iotg-headers-5.15.0-1004_5.15.0-1004.6_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-intel-iotg/linux-headers-5.15.0-1004-intel-iotg_5.15.0-1004.6_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-intel-iotg/linux-headers-5.15.0-1004-intel-iotg_5.15.0-1004.6_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-intel-iotg/linux-intel-iotg-headers-5.15.0-1004_5.15.0-1004.6_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-intel-iotg-5.15/linux-headers-5.15.0-1004-intel-iotg_5.15.0-1004.6_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-intel-iotg-5.15/linux-headers-5.15.0-1004-intel-iotg_5.15.0-1004.6_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-intel-iotg-5.15/linux-intel-iotg-headers-5.15.0-1004_5.15.0-1004.6_all.deb"},
+			gccVersion:  "10",
+			firstExtra:  "1004",
+			flavor:      "intel-iotg",
+			err:         nil,
+		},
+	},
+	{
+		config: kernelrelease.KernelRelease{
+			Fullversion:      "5.15.0",
+			Version:          5,
+			PatchLevel:       15,
+			Sublevel:         0,
+			Extraversion:     "24-lowlatency-hwe-5.15",
+			FullExtraversion: "-24-lowlatency-hwe-5.15",
+			Architecture:     "amd64",
+		},
+		kernelversion: "24~20.04.3",
+		expected: struct {
+			headersURLs []string
+			urls        []string
+			gccVersion  string
+			firstExtra  string
+			flavor      string
+			err         error
+		}{
+			headersURLs: []string{},
+			urls:        []string{"https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-5.15.0-24-lowlatency-hwe-5.15_5.15.0-24.24~20.04.3_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-5.15.0-24-lowlatency-hwe_5.15.0-24.24~20.04.3_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-lowlatency-hwe-headers-5.15.0-24_5.15.0-24.24~20.04.3_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-5.15.0-24-lowlatency-hwe-5.15_5.15.0-24.24~20.04.3_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-lowlatency-hwe/linux-headers-5.15.0-24-lowlatency-hwe-5.15_5.15.0-24.24~20.04.3_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-lowlatency-hwe/linux-headers-5.15.0-24-lowlatency-hwe_5.15.0-24.24~20.04.3_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-lowlatency-hwe/linux-lowlatency-hwe-headers-5.15.0-24_5.15.0-24.24~20.04.3_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-lowlatency-hwe/linux-headers-5.15.0-24-lowlatency-hwe-5.15_5.15.0-24.24~20.04.3_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-lowlatency-hwe-5.15/linux-headers-5.15.0-24-lowlatency-hwe-5.15_5.15.0-24.24~20.04.3_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-lowlatency-hwe-5.15/linux-headers-5.15.0-24-lowlatency-hwe_5.15.0-24.24~20.04.3_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-lowlatency-hwe-5.15/linux-lowlatency-hwe-headers-5.15.0-24_5.15.0-24.24~20.04.3_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-lowlatency-hwe-5.15/linux-headers-5.15.0-24-lowlatency-hwe-5.15_5.15.0-24.24~20.04.3_amd64.deb"},
+			gccVersion:  "10",
+			firstExtra:  "24",
+			flavor:      "lowlatency-hwe",
+			err:         fmt.Errorf("kernel headers not found"),
+		},
+	},
+	{
+		config: kernelrelease.KernelRelease{
+			Fullversion:      "3.13.0",
+			Version:          3,
+			PatchLevel:       13,
+			Sublevel:         0,
+			Extraversion:     "100",
+			FullExtraversion: "-100",
+			Architecture:     "amd64",
+		},
+		kernelversion: "147",
+		expected: struct {
+			headersURLs []string
+			urls        []string
+			gccVersion  string
+			firstExtra  string
+			flavor      string
+			err         error
+		}{
+			headersURLs: []string{},
+			urls:        []string{"https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-3.13.0-100_3.13.0-100.147_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-3.13.0-100-generic_3.13.0-100.147_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-generic-headers-3.13.0-100_3.13.0-100.147_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-3.13.0-100_3.13.0-100.147_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-generic/linux-headers-3.13.0-100_3.13.0-100.147_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-generic/linux-headers-3.13.0-100-generic_3.13.0-100.147_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-generic/linux-generic-headers-3.13.0-100_3.13.0-100.147_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-generic/linux-headers-3.13.0-100_3.13.0-100.147_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-generic-3.13/linux-headers-3.13.0-100_3.13.0-100.147_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-generic-3.13/linux-headers-3.13.0-100-generic_3.13.0-100.147_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-generic-3.13/linux-generic-headers-3.13.0-100_3.13.0-100.147_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-generic-3.13/linux-headers-3.13.0-100_3.13.0-100.147_amd64.deb"},
+			gccVersion:  "4.8",
+			firstExtra:  "100",
+			flavor:      "generic",
+			err:         nil,
+		},
+	},
+	{
+		config: kernelrelease.KernelRelease{
+			Fullversion:      "3.16.0",
+			Version:          3,
+			PatchLevel:       16,
+			Sublevel:         0,
+			Extraversion:     "38-lts-utopic",
+			FullExtraversion: "-38-lts-utopic",
+			Architecture:     "amd64",
+		},
+		kernelversion: "52~14.04.1",
+		expected: struct {
+			headersURLs []string
+			urls        []string
+			gccVersion  string
+			firstExtra  string
+			flavor      string
+			err         error
+		}{
+			headersURLs: []string{},
+			urls:        []string{"https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-3.16.0-38-lts-utopic_3.16.0-38.52~14.04.1_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-3.16.0-38-lts-utopic_3.16.0-38.52~14.04.1_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-lts-utopic-headers-3.16.0-38_3.16.0-38.52~14.04.1_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-lts-utopic/linux-headers-3.16.0-38-lts-utopic_3.16.0-38.52~14.04.1_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-lts-utopic/linux-headers-3.16.0-38-lts-utopic_3.16.0-38.52~14.04.1_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-lts-utopic/linux-lts-utopic-headers-3.16.0-38_3.16.0-38.52~14.04.1_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-lts-utopic-3.16/linux-headers-3.16.0-38-lts-utopic_3.16.0-38.52~14.04.1_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-lts-utopic-3.16/linux-headers-3.16.0-38-lts-utopic_3.16.0-38.52~14.04.1_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-lts-utopic-3.16/linux-lts-utopic-headers-3.16.0-38_3.16.0-38.52~14.04.1_all.deb"},
+			gccVersion:  "6",
+			firstExtra:  "38",
+			flavor:      "lts-utopic",
+			err:         nil,
+		},
+	},
+	{
+		config: kernelrelease.KernelRelease{
+			Fullversion:      "5.18.0",
+			Version:          5,
+			PatchLevel:       18,
+			Sublevel:         0,
+			Extraversion:     "1001-kvm",
+			FullExtraversion: "-1001-kvm",
+			Architecture:     "amd64",
+		},
+		kernelversion: "1",
+		expected: struct {
+			headersURLs []string
+			urls        []string
+			gccVersion  string
+			firstExtra  string
+			flavor      string
+			err         error
+		}{
+			headersURLs: []string{"https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-kvm/linux-headers-5.18.0-1001-kvm_5.18.0-1001.1_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-kvm/linux-kvm-headers-5.18.0-1001_5.18.0-1001.1_all.deb"},
+			urls:        []string{"https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-5.18.0-1001-kvm_5.18.0-1001.1_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-5.18.0-1001-kvm_5.18.0-1001.1_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-kvm-headers-5.18.0-1001_5.18.0-1001.1_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-kvm/linux-headers-5.18.0-1001-kvm_5.18.0-1001.1_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-kvm/linux-headers-5.18.0-1001-kvm_5.18.0-1001.1_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-kvm/linux-kvm-headers-5.18.0-1001_5.18.0-1001.1_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-kvm-5.18/linux-headers-5.18.0-1001-kvm_5.18.0-1001.1_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-kvm-5.18/linux-headers-5.18.0-1001-kvm_5.18.0-1001.1_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-kvm-5.18/linux-kvm-headers-5.18.0-1001_5.18.0-1001.1_all.deb"},
+			gccVersion:  "11",
+			firstExtra:  "1001",
+			flavor:      "kvm",
+			err:         nil,
+		},
+	},
+}
+
+func TestUbuntuHeadersURLFromRelease(t *testing.T) {
+	for _, test := range tests {
+		expected := test.expected.headersURLs
+
+		// setup input
+		input := struct {
+			config kernelrelease.KernelRelease
+			kv     string
+		}{
+			test.config,
+			test.kernelversion,
+		}
+
+		// call function
+		gotURLs, err := ubuntuHeadersURLFromRelease(input.config, input.kv)
+		// compare errors
+		// there are no official errors, so comparing fmt.Errorf() doesn't really work
+		// compare error message text instead
+		if err != nil && test.expected.err != nil && err.Error() != test.expected.err.Error() {
+			t.Fatalf("Unexpected error encountered with Test Input: '%v' | Error: '%s'", input, err)
+		}
+
+		// check length of URL slice returned
+		if len(gotURLs) != len(expected) {
+			t.Fatalf("Slice sizes don't match! Test Input: '%v' | Got: '%v' / Want: '%v'", input, gotURLs, expected)
+		}
+
+		// check values are exact match
+		for i, v := range gotURLs {
+			if v != expected[i] {
+				t.Fatalf("Slice values don't match! Test Input: '%v' | Got: '%v' / Want: '%v'", input, gotURLs, expected)
+			}
+		}
+	}
+}
+
+func TestFetchUbuntuKernelURL(t *testing.T) {
+	for _, test := range tests {
+
+		// setup baseURLs - leave out security for sake of simplicity
+		baseURLs := []string{}
+		if test.config.Architecture.String() == "amd64" {
+			baseURLs = []string{
+				"https://mirrors.edge.kernel.org/ubuntu/pool/main/l",
+			}
+		} else {
+			baseURLs = []string{
+				"http://ports.ubuntu.com/ubuntu-ports/pool/main/l",
+			}
+		}
+
+		for _, url := range baseURLs {
+			expected := test.expected.urls
+
+			// setup input
+			input := struct {
+				baseURL string
+				config  kernelrelease.KernelRelease
+				kv      string
+			}{
+				url,
+				test.config,
+				test.kernelversion,
+			}
+
+			// call function
+			gotURLs, err := fetchUbuntuKernelURL(input.baseURL, input.config, input.kv)
+			if err != nil {
+				t.Fatalf("Unexpected error encountered with Test Input: '%v' | Error: '%s'", input, err)
+			}
+
+			// check length of URL slice returned
+			if len(gotURLs) != len(expected) {
+				t.Fatalf("Slice sizes don't match! Test Input: '%v' | Got: '%v' / Want: '%v'", input, gotURLs, expected)
+			}
+
+			// check values are exact match
+			for i, v := range gotURLs {
+				if v != expected[i] {
+					t.Fatalf("Slice values don't match! Test Input: '%v' | Got: '%v' / Want: '%v'", input, gotURLs, expected)
+				}
+			}
+		}
+	}
+}
+
+func TestUbuntuGCCVersionFromKernelRelease(t *testing.T) {
+	for _, test := range tests {
+		gotGCCVersion := ubuntuGCCVersionFromKernelRelease(test.config)
+		if gotGCCVersion != test.expected.gccVersion {
+			t.Errorf(
+				"Test Input: [ '%v' ] | Got: [ '%s' ] / Want: [ '%s' ]",
+				test.config,
+				gotGCCVersion,
+				test.expected.gccVersion,
+			)
+		}
+	}
+}
+
+func TestParseUbuntuExtraVersion(t *testing.T) {
+	for _, test := range tests {
+		gotFirstExtra, gotFlavor := parseUbuntuExtraVersion(test.config.Extraversion)
+		if gotFirstExtra != test.expected.firstExtra {
+			t.Errorf(
+				"Test Input: [ '%s' ] | Got: [ '%s' ] / Want: [ '%s' ]",
+				test.config.Extraversion,
+				gotFirstExtra,
+				test.expected.firstExtra,
+			)
+		}
+		if gotFlavor != test.expected.flavor {
+			t.Errorf(
+				"Test Input: [ '%s' ] | Got: [ '%s' ] / Want: [ '%s' ]",
+				test.config.Extraversion,
+				gotFlavor,
+				test.expected.flavor,
+			)
+		}
+	}
+}

--- a/pkg/driverbuilder/builder/ubuntu_test.go
+++ b/pkg/driverbuilder/builder/ubuntu_test.go
@@ -298,11 +298,12 @@ func TestFetchUbuntuKernelURL(t *testing.T) {
 
 func TestUbuntuGCCVersionFromKernelRelease(t *testing.T) {
 	for _, test := range tests {
-		gotGCCVersion := ubuntuGCCVersionFromKernelRelease(test.config)
+		input := test.config
+		gotGCCVersion := ubuntuGCCVersionFromKernelRelease(input)
 		if gotGCCVersion != test.expected.gccVersion {
 			t.Errorf(
 				"Test Input: [ '%v' ] | Got: [ '%s' ] / Want: [ '%s' ]",
-				test.config,
+				input,
 				gotGCCVersion,
 				test.expected.gccVersion,
 			)
@@ -312,11 +313,12 @@ func TestUbuntuGCCVersionFromKernelRelease(t *testing.T) {
 
 func TestParseUbuntuExtraVersion(t *testing.T) {
 	for _, test := range tests {
-		gotFirstExtra, gotFlavor := parseUbuntuExtraVersion(test.config.Extraversion)
+		input := test.config.Extraversion
+		gotFirstExtra, gotFlavor := parseUbuntuExtraVersion(input)
 		if gotFirstExtra != test.expected.firstExtra {
 			t.Errorf(
 				"Test Input: [ '%s' ] | Got: [ '%s' ] / Want: [ '%s' ]",
-				test.config.Extraversion,
+				input,
 				gotFirstExtra,
 				test.expected.firstExtra,
 			)
@@ -324,7 +326,7 @@ func TestParseUbuntuExtraVersion(t *testing.T) {
 		if gotFlavor != test.expected.flavor {
 			t.Errorf(
 				"Test Input: [ '%s' ] | Got: [ '%s' ] / Want: [ '%s' ]",
-				test.config.Extraversion,
+				input,
 				gotFlavor,
 				test.expected.flavor,
 			)

--- a/pkg/kernelrelease/kernelrelease.go
+++ b/pkg/kernelrelease/kernelrelease.go
@@ -47,6 +47,11 @@ func (kr *KernelRelease) IsGKE() bool {
 	return strings.HasSuffix(kr.Extraversion, "gke")
 }
 
+// IsAWS tells whether the current kernel release is for AWS by looking at its name.
+func (kr *KernelRelease) IsAWS() bool {
+	return strings.HasSuffix(kr.Extraversion, "aws")
+}
+
 // FromString extracts a KernelRelease object from string.
 func FromString(kernelVersionStr string) KernelRelease {
 	kv := KernelRelease{}

--- a/pkg/kernelrelease/kernelrelease.go
+++ b/pkg/kernelrelease/kernelrelease.go
@@ -4,7 +4,6 @@ import (
 	"log"
 	"regexp"
 	"strconv"
-	"strings"
 )
 
 var (
@@ -40,16 +39,6 @@ type KernelRelease struct {
 	Extraversion     string       `json:"extra_version"`
 	FullExtraversion string       `json:"full_extra_version"`
 	Architecture     Architecture `json:"architecture"`
-}
-
-// IsGKE tells whether the current kernel release is for GKE by looking at its name.
-func (kr *KernelRelease) IsGKE() bool {
-	return strings.HasSuffix(kr.Extraversion, "gke")
-}
-
-// IsAWS tells whether the current kernel release is for AWS by looking at its name.
-func (kr *KernelRelease) IsAWS() bool {
-	return strings.HasSuffix(kr.Extraversion, "aws")
 }
 
 // FromString extracts a KernelRelease object from string.

--- a/test/aarch64/configs/ubuntu.yaml
+++ b/test/aarch64/configs/ubuntu.yaml
@@ -1,5 +1,5 @@
 kernelversion: 199
-kernelrelease: 4.15.0-188
+kernelrelease: 4.15.0-188-generic
 target: ubuntu-generic
 kernelurls: [
   "https://download.falco.org/fixtures/driverkit/aarch64_devel/linux-headers-4.15.0-188_4.15.0-188.199_all.deb",

--- a/test/aarch64/configs/ubuntu.yaml
+++ b/test/aarch64/configs/ubuntu.yaml
@@ -1,5 +1,5 @@
 kernelversion: 199
-kernelrelease: 4.15.0-188-generic
+kernelrelease: 4.15.0-188
 target: ubuntu-generic
 kernelurls: [
   "https://download.falco.org/fixtures/driverkit/aarch64_devel/linux-headers-4.15.0-188_4.15.0-188.199_all.deb",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area cmd

> /area pkg

> /area docs

> /area tests


**What this PR does / why we need it**:

Trying to simplify and expand Driverkit's Ubuntu support:
- Rather than having `ubuntu-generic` and `ubuntu-aws`, simplify to just `ubuntu`
- Expand support to more than just `generic` and `aws`, as described in: #144 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #144 

**Special notes for your reviewer**:

This work is also built in part on top of the work @amalone-scwx did in some internal testing - wanted to make sure I give credit where credit is due :)

**Does this PR introduce a user-facing change?**:

Yes, simplifying Ubuntu target types to just `--target ubuntu`, though backwards compatibility with `ubuntu-aws` and `ubuntu-generic` should still work (but I would argue need to be deprecated in the future). 

The one "gotcha" to look out for with this change is that now the Ubuntu "Flavor" (ex: aws, generic, kvm, oracle, etc) is now dynamically parsed from the `kernelrelease` field. If the `kernelrelease` passed in is formatted incorrectly or omits that flavor, then `generic` is the assumed flavor.

For example, if a config looks like:
```
kernelversion: 199
kernelrelease: 4.15.0-188
target: ubuntu
```
The updated code will assume that `generic` is the "flavor" here since the `target` is no longer a reliable way to get that information.

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
Simplifying and expanding Ubuntu support into just `--target ubuntu` and adding support for all flavors! `ubuntu-generic` and `ubuntu-aws` target types are still supported for backwards compatibility, but should be deprecated.
Massive overhaul to the go-side of the Ubuntu builder which now parses the Ubuntu "Flavor" from the kernelrelease and uses it to build URL paths to search for kernel headers, meaning all Ubuntu flavors should now be supported rather than just AWS and generic.
```
