### PR TITLE
new(pkg): drop requirements of `kernel` package for amazonlinux2 builder

### DIFF
--- a/pkg/driverbuilder/builder/amazonlinux.go
+++ b/pkg/driverbuilder/builder/amazonlinux.go
@@ -119,23 +119,20 @@ func script(c Config, targetType Type) (string, error) {
 	kv := kernelReleaseFromBuildConfig(c.Build)
 
 	var urls []string
-    if c.KernelUrls == nil {
-        // Check (and filter) existing kernels before continuing
-        var packages []string
-        packages, err = fetchAmazonLinuxPackagesURLs(kv, targetType)
-        if err != nil {
-            return "", err
-        }
-        urls, err = getResolvingURLs(packages)
-    } else {
-        urls, err = getResolvingURLs(c.KernelUrls)
-    }
-    if err != nil {
-        return "", err
-    }
-    if len(urls) < 2 {
-        return "", fmt.Errorf("target %s needs to find both kernel and kernel-devel packages", targetType)
-    }
+	if c.KernelUrls == nil {
+		// Check (and filter) existing kernels before continuing
+		var packages []string
+		packages, err = fetchAmazonLinuxPackagesURLs(kv, targetType)
+		if err != nil {
+			return "", err
+		}
+		urls, err = getResolvingURLs(packages)
+	} else {
+		urls, err = getResolvingURLs(c.KernelUrls)
+	}
+	if err != nil {
+		return "", err
+	}
 
 	td := amazonlinuxTemplateData{
 		DriverBuildDir:     DriverDirectory,
@@ -291,8 +288,7 @@ func fetchAmazonLinuxPackagesURLs(kv kernelrelease.KernelRelease, targetType Typ
 		}
 
 		// Found, do not continue
-		// todo > verify amazonlinux always needs 2 packages (kernel and kernel-devel) too
-		if len(urls) == 2 {
+		if len(urls) > 0 {
 			break
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Federico Di Pierro <nierro92@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area cmd

/area pkg

> /area docs

> /area tests


**What this PR does / why we need it**:

Dropped requirement of 2 urls for amazonlinux (i could build various kernels without it; more testing needed!).

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
cleanup(pkg): amazonlinux2 builder does now only need kernel-devel url.
```
