### PR TITLE
fix: builder container stop, when already stopped

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ integration_test: $(test_configs)
 
 .PHONY: $(test_configs)
 $(test_configs): ${driverkit}
-	${driverkit} docker -c $@ --builderimage falcosecurity/driverkit-builder:latest -l debug --timeout 300
+	${driverkit} docker -c $@ --builderimage falcosecurity/driverkit-builder:latest -l debug --timeout 600
 
 .PHONY: ${driverkit_docgen}
 ${driverkit_docgen}: ${PWD}/docgen

--- a/pkg/driverbuilder/docker.go
+++ b/pkg/driverbuilder/docker.go
@@ -324,7 +324,7 @@ func (bp *DockerBuildProcessor) cleanup(cli *client.Client, ID string) {
 		bp.clean = true
 		logger.Debug("context canceled")
 		duration := time.Second
-		if err := cli.ContainerStop(context.Background(), ID, &duration); err != nil {
+		if err := cli.ContainerStop(context.Background(), ID, &duration); err != nil && !client.IsErrNotFound(err) {
 			logger.WithError(err).WithField("container_id", ID).Error("error stopping container")
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area cmd

/area pkg

> /area docs

> /area tests


**What this PR does / why we need it**:

Like #167 but for builder container. Avoids leaving with error even if kmod/probes were built but we fail to stop the container because it is already stopped.

Moreover, increased `integration_tests` target build timeout.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
