### PR TITLE
fix(test): fixed arm64 tests: eBPF probe requirement is now kernel >= 4.17

### DIFF
--- a/test/aarch64/configs/ubuntu.yaml
+++ b/test/aarch64/configs/ubuntu.yaml
@@ -8,4 +8,3 @@ kernelurls: [
 architecture: arm64
 output:
   module: /tmp/ubuntu_aarch64.ko
-  probe: /tmp/ubuntu_aarch64.o

--- a/test/aarch64/configs/ubuntu_aws.yaml
+++ b/test/aarch64/configs/ubuntu_aws.yaml
@@ -8,4 +8,3 @@ kernelurls: [
 architecture: arm64
 output:
   module: /tmp/ubuntu-aws_aarch64.ko
-  probe: /tmp/ubuntu-aws_aarch64.o


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area tests

**What this PR does / why we need it**:

This fixes integration tests for arm64 after https://github.com/falcosecurity/libs/pull/416.  
Basically, 416 fixed drivers support for arm64; unfortunately, we had to bump the minimum required version for ebpf probe and kmod; see https://github.com/falcosecurity/libs#drivers-officially-supported-architectures.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
