### PR TITLE
new(pkg/driverbuilder): added amazonlinux2022 builder.

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ kernelrelease: 4.14.26-46.32.amzn1.x86_64
 target: amazonlinux
 output:
     module: /tmp/falco_amazonlinux_4.14.26-46.32.amzn1.x86_64.ko
-driverversion: be1ea2d9482d0e6e2cb14a0fd7e08cbecf517f94
+driverversion: master
 ```
 
 ### amazonlinux 2
@@ -152,7 +152,18 @@ target: amazonlinux2
 output:
     module: /tmp/falco_amazonlinux2_4.14.171-136.231.amzn2.x86_64.ko
     probe: /tmp/falco_amazonlinux2_4.14.171-136.231.amzn2.x86_64.o
-driverversion: be1ea2d9482d0e6e2cb14a0fd7e08cbecf517f94
+driverversion: master
+```
+
+### amazonlinux 2022
+
+```yaml
+kernelrelease: 5.10.96-90.460.amzn2022.x86_64
+target: amazonlinux2022
+output:
+    module: /tmp/falco_amazonlinux2022_5.10.96-90.460.amzn2022.x86_64.ko
+    probe: /tmp/falco_amazonlinux2022_5.10.96-90.460.amzn2022.x86_64.o
+driverversion: master
 ```
 
 ### debian

--- a/cmd/testdata/completion-targets.txt
+++ b/cmd/testdata/completion-targets.txt
@@ -1,5 +1,6 @@
 amazonlinux
 amazonlinux2
+amazonlinux2022
 centos
 debian
 flatcar


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area pkg

**What this PR does / why we need it**:

It adds amazonlinux2022 builder.
Moreover, refactored amazonlinux file making it easier to implement new builders.
Finally, updated README with the new al2022 example.

Tested: it is able to find the headers; then it fails to build the kmod because of glibc version issues (we really **need** multiple builders). eBPF probe builds fine.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
new(pkg): added amazonlinux 2022 builder.
```
