### PR TITLE
chore: refactored builder interface to reduce boiler plate in each builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,8 +409,7 @@ func init() {
 Now, you can implement the `builder.Builder` interface for the `archlinux` struct
 you just registered.
 
-Here's a very minimalistic example.
-
+Here's a very minimalistic example:
 
 ```go
 func (c archlinux) Name() string {

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # driverkit
 
+[![Latest](https://img.shields.io/github/v/release/falcosecurity/driverkit?style=for-the-badge)](https://github.com/falcosecurity/driverkit/releases/latest)
+![Architectures](https://img.shields.io/badge/ARCHS-x86__64%7Caarch64-blueviolet?style=for-the-badge)
+
 Status: **Under development**
 
-A command line tool that can be used to build the Falco kernel module and eBPF probe.
-
+A command line tool that can be used to build the [Falco](https://github.com/falcosecurity/falco) kernel module and eBPF probe.
 
 ## Usage
 
@@ -191,6 +193,24 @@ target: flatcar
 output:
   module: /tmp/falco-flatcar-3185.0.0.ko
   probe: /tmp/falco-flatcar-3185.0.0.o
+driverversion: master
+```
+
+### archlinux
+
+Example configuration file to build both the Kernel module and eBPF probe for Archlinux.
+Note: archlinux target uses the [Arch Linux Archive](https://wiki.archlinux.org/title/Arch_Linux_Archive) to fetch
+all ever supported kernel releases.  
+For arm64, it uses an user-provided mirror, as no official mirror is available: http://tardis.tiny-vps.com/aarm/.  
+The mirror has been up and updated since 2015.
+
+```yaml
+kernelversion: 1
+kernelrelease: 4.20.3-arch1
+target: archlinux
+output:
+  module: /tmp/falco-arch.ko
+  probe: /tmp/falco-arch.o
 driverversion: master
 ```
 
@@ -393,13 +413,45 @@ Here's a very minimalistic example.
 
 
 ```go
-func (v archLinux) Script(c Config) (string, error) {
-  return "echo 'hello world'", nil
+func (c archlinux) Name() string {
+    return TargetTypeArchlinux.String()
+}
+
+func (c archlinux) TemplateScript() string {
+	return archlinuxTemplate
+}
+
+func (c archlinux) URLs(cfg Config, kr kernelrelease.KernelRelease) ([]string, error) {
+    urls := []string{}
+    if kr.Architecture == "amd64" {
+        urls = append(urls, fmt.Sprintf("https://archive.archlinux.org/packages/l/linux-headers/linux-headers-%s.%s-%d-%s.pkg.tar.xz",
+            kr.Fullversion,
+            kr.Extraversion,
+            cfg.KernelVersion,
+            kr.Architecture.ToNonDeb()))
+    } else {
+        urls = append(urls, fmt.Sprintf("http://tardis.tiny-vps.com/aarm/packages/l/linux-%s-headers/linux-%s-headers-%s-%d-%s.pkg.tar.xz",
+            kr.Architecture.ToNonDeb(),
+            kr.Architecture.ToNonDeb(),
+            kr.Fullversion,
+            cfg.KernelVersion,
+            kr.Architecture.ToNonDeb()))
+    }
+    return urls, nil
+}
+
+func (c archlinux) TemplateData(cfg Config, kr kernelrelease.KernelRelease, urls []string) interface{} {
+    return archlinuxTemplateData{
+        commonTemplateData: cfg.toTemplateData(),
+        KernelDownloadURL:  urls[0],
+        GCCVersion:         archlinuxGccVersionFromKernelRelease(kr),
+    }
 }
 ```
 
-Essentially, the `Script` function that you are implementing will need to return a string containing
-a `bash` script that will be executed by driverkit at build time.  
+Essentially, the various methods that you are implementing are needed to:
+* filling the script template (see below), that is a `bash` script that will be executed by driverkit at build time 
+* fetching kernel headers urls that will later be downloaded inside the builder container, and used for the driver build
 
 Under `pkg/driverbuilder/builder/templates` folder, you can find all the template scripts for the supported builders.  
 Adding a new template there and using `go:embed` to include it in your builder, allows leaner code 
@@ -426,7 +478,8 @@ If the user specifies:
 The `/tmp/driver` MUST be interpolated from the `DriverDirectory` constant from [`builders.go`](/pkg/driverbuilder/builder/builders.go).
 
 If you look at the various builder implemented, you will see that the task of creating a new builder
-can be easy or difficult depending on how the distribution ships their artifacts.
+can be easy or difficult depending on how the distribution ships their artifacts.  
+Indeed, the hardest part is fetching the kernel headers urls for each distro. 
 
 ### 3. Customize GCC version
 
@@ -453,4 +506,7 @@ For an example, you can check out Debian builder, namely: `debianLLVMVersionFrom
 When creating a new builder, it is recommended to check that [kernel-crawler](https://github.com/falcosecurity/kernel-crawler) 
 can also support collecting the new builders kernel versions and header package URLs. This will make sure that the latest drivers 
 for the new builder are automatically built by [test-infra](https://github.com/falcosecurity/test-infra). If required, add a feature request
-for support for the new builder on the [kernel-crawler](https://github.com/falcosecurity/kernel-crawler) repository.
+for support for the new builder on the kernel-crawler repository.  
+Note: be sure that the crawler you wants to add is interesting for the community as a whole.  
+For example, an archlinux crawler doesn't make much sense, because Arch is a rolling release and we should not support  
+any past Arch kernel for Falco.

--- a/pkg/driverbuilder/builder/builders.go
+++ b/pkg/driverbuilder/builder/builders.go
@@ -108,8 +108,8 @@ func (c Config) toTemplateData() commonTemplateData {
 		ModuleDownloadURL: fmt.Sprintf("%s/%s.tar.gz", c.DownloadBaseURL, c.DriverVersion),
 		ModuleDriverName:  c.DriverName,
 		ModuleFullPath:    ModuleFullPath,
-		BuildModule:       len(c.Build.ModuleFilePath) > 0,
-		BuildProbe:        len(c.Build.ProbeFilePath) > 0,
+		BuildModule:       len(c.ModuleFilePath) > 0,
+		BuildProbe:        len(c.ProbeFilePath) > 0,
 	}
 }
 

--- a/pkg/driverbuilder/builder/debian.go
+++ b/pkg/driverbuilder/builder/debian.go
@@ -41,14 +41,7 @@ func (v debian) TemplateScript() string {
 }
 
 func (v debian) URLs(_ Config, kr kernelrelease.KernelRelease) ([]string, error) {
-	kurls, err := fetchDebianKernelURLs(kr)
-	if err != nil {
-		return nil, err
-	}
-	if len(kurls) < 3 {
-		return nil, fmt.Errorf(HeadersTooFewFoundErrFmt, 3, len(kurls))
-	}
-	return kurls, nil
+	return fetchDebianKernelURLs(kr)
 }
 
 func (v debian) TemplateData(c Config, kr kernelrelease.KernelRelease, urls []string) interface{} {
@@ -59,6 +52,14 @@ func (v debian) TemplateData(c Config, kr kernelrelease.KernelRelease, urls []st
 		LLVMVersion:        debianLLVMVersionFromKernelRelease(kr),
 		KernelArch:         kr.Architecture.String(),
 	}
+}
+
+func (v debian) MinimumURLs() int {
+	// We need:
+	// kernel devel
+	// kernel devel common
+	// kbuild package
+	return 3
 }
 
 func fetchDebianKernelURLs(kr kernelrelease.KernelRelease) ([]string, error) {

--- a/pkg/driverbuilder/builder/debian.go
+++ b/pkg/driverbuilder/builder/debian.go
@@ -16,6 +16,12 @@ var debianTemplate string
 // TargetTypeDebian identifies the Debian target.
 const TargetTypeDebian Type = "debian"
 
+// We need:
+// kernel devel
+// kernel devel common
+// kbuild package
+const debianRequiredURLs = 3
+
 func init() {
 	BuilderByTarget[TargetTypeDebian] = &debian{}
 }
@@ -55,11 +61,7 @@ func (v debian) TemplateData(c Config, kr kernelrelease.KernelRelease, urls []st
 }
 
 func (v debian) MinimumURLs() int {
-	// We need:
-	// kernel devel
-	// kernel devel common
-	// kbuild package
-	return 3
+	return debianRequiredURLs
 }
 
 func fetchDebianKernelURLs(kr kernelrelease.KernelRelease) ([]string, error) {

--- a/pkg/driverbuilder/builder/debian.go
+++ b/pkg/driverbuilder/builder/debian.go
@@ -25,6 +25,7 @@ type debianTemplateData struct {
 	KernelDownloadURLS []string
 	KernelLocalVersion string
 	LLVMVersion        string
+	KernelArch         string
 }
 
 // debian is a driverkit target.
@@ -56,6 +57,7 @@ func (v debian) TemplateData(c Config, kr kernelrelease.KernelRelease, urls []st
 		KernelDownloadURLS: urls,
 		KernelLocalVersion: kr.FullExtraversion,
 		LLVMVersion:        debianLLVMVersionFromKernelRelease(kr),
+		KernelArch:         kr.Architecture.String(),
 	}
 }
 

--- a/pkg/driverbuilder/builder/redhat.go
+++ b/pkg/driverbuilder/builder/redhat.go
@@ -36,6 +36,11 @@ func (v redhat) URLs(_ Config, _ kernelrelease.KernelRelease) ([]string, error) 
 	return nil, nil
 }
 
+func (v redhat) MinimumURLs() int {
+	// We don't need any url
+	return 0
+}
+
 func (v redhat) TemplateData(c Config, kr kernelrelease.KernelRelease, _ []string) interface{} {
 	return redhatTemplateData{
 		commonTemplateData: c.toTemplateData(),

--- a/pkg/driverbuilder/builder/redhat.go
+++ b/pkg/driverbuilder/builder/redhat.go
@@ -1,10 +1,8 @@
 package builder
 
 import (
-	"bytes"
 	_ "embed"
 	"github.com/falcosecurity/driverkit/pkg/kernelrelease"
-	"text/template"
 )
 
 //go:embed templates/redhat.sh
@@ -22,36 +20,25 @@ func init() {
 }
 
 type redhatTemplateData struct {
-	DriverBuildDir    string
-	KernelPackage     string
-	ModuleDownloadURL string
-	ModuleDriverName  string
-	ModuleFullPath    string
-	BuildModule       bool
-	BuildProbe        bool
+	commonTemplateData
+	KernelPackage string
 }
 
-func (v redhat) Script(cfg Config, kr kernelrelease.KernelRelease) (string, error) {
-	t := template.New(string(TargetTypeRedhat))
-	parsed, err := t.Parse(redhatTemplate)
-	if err != nil {
-		return "", err
-	}
+func (v redhat) Name() string {
+	return TargetTypeRedhat.String()
+}
 
-	td := redhatTemplateData{
-		DriverBuildDir:    DriverDirectory,
-		KernelPackage:     kr.Fullversion + kr.FullExtraversion,
-		ModuleDownloadURL: moduleDownloadURL(cfg),
-		ModuleDriverName:  cfg.DriverName,
-		ModuleFullPath:    ModuleFullPath,
-		BuildModule:       len(cfg.Build.ModuleFilePath) > 0,
-		BuildProbe:        len(cfg.Build.ProbeFilePath) > 0,
-	}
+func (v redhat) TemplateScript() string {
+	return redhatTemplate
+}
 
-	buf := bytes.NewBuffer(nil)
-	err = parsed.Execute(buf, td)
-	if err != nil {
-		return "", err
+func (v redhat) URLs(_ Config, _ kernelrelease.KernelRelease) ([]string, error) {
+	return nil, nil
+}
+
+func (v redhat) TemplateData(c Config, kr kernelrelease.KernelRelease, _ []string) interface{} {
+	return redhatTemplateData{
+		commonTemplateData: c.toTemplateData(),
+		KernelPackage:      kr.Fullversion + kr.FullExtraversion,
 	}
-	return buf.String(), nil
 }

--- a/pkg/driverbuilder/builder/templates/debian.sh
+++ b/pkg/driverbuilder/builder/templates/debian.sh
@@ -27,7 +27,7 @@ cp -r usr/* /usr
 cp -r lib/* /lib
 
 cd /usr/src
-sourcedir=$(find . -type d -name "linux-headers-*%s" | head -n 1 | xargs readlink -f)
+sourcedir=$(find . -type d -name "linux-headers-*{{ .KernelArch }}" | head -n 1 | xargs readlink -f)
 
 {{ if .BuildModule }}
 # Build the module

--- a/pkg/driverbuilder/builder/ubuntu.go
+++ b/pkg/driverbuilder/builder/ubuntu.go
@@ -54,6 +54,12 @@ func (v ubuntu) URLs(c Config, kr kernelrelease.KernelRelease) ([]string, error)
 	return ubuntuHeadersURLFromRelease(kr, c.Build.KernelVersion)
 }
 
+func (v ubuntu) MinimumURLs() int {
+	// We expect both a common "_all" package,
+	// and an arch dependent package.
+	return 2
+}
+
 func (v ubuntu) TemplateData(_ Config, kr kernelrelease.KernelRelease, urls []string) interface{} {
 	// parse the flavor out of the kernelrelease extraversion
 	_, flavor := parseUbuntuExtraVersion(kr.Extraversion)

--- a/pkg/driverbuilder/docker.go
+++ b/pkg/driverbuilder/docker.go
@@ -124,7 +124,7 @@ func (bp *DockerBuildProcessor) Start(b *builder.Build) error {
 
 	// Generate the build script from the builder
 	kr := c.Build.KernelReleaseFromBuildConfig()
-	driverkitScript, err := v.Script(c, kr)
+	driverkitScript, err := builder.Script(v, c, kr)
 	if err != nil {
 		return err
 	}

--- a/pkg/driverbuilder/kubernetes.go
+++ b/pkg/driverbuilder/kubernetes.go
@@ -84,7 +84,7 @@ func (bp *KubernetesBuildProcessor) buildModule(build *builder.Build) error {
 
 	// generate the build script from the builder
 	kr := c.Build.KernelReleaseFromBuildConfig()
-	res, err := v.Script(c, kr)
+	res, err := builder.Script(v, c, kr)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind design

**Any specific area of the project related to this PR?**

/area pkg

**What this PR does / why we need it**:

Refactor the single method Builder interface:
```Go
Script(c Config, kr kernelrelease.KernelRelease) (string, error)
```
to:
```Go
Name() string
TemplateScript() string
URLs(c Config, kr kernelrelease.KernelRelease) ([]string, error)
TemplateData(c Config, kr kernelrelease.KernelRelease, urls []string) interface{}
```
To reduce boiler plate of implementing the same Script method for each new builder.
This cuts down ~150locs from builders and makes writing a new builder even easier.

Moreover, updated README with new informations (archlinux builder too!).

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
