### PR TITLE
adjust ubuntu gcc versions

### DIFF
--- a/pkg/driverbuilder/builder/ubuntu.go
+++ b/pkg/driverbuilder/builder/ubuntu.go
@@ -216,8 +216,7 @@ func fetchUbuntuGenericKernelURL(baseURL string, kr kernelrelease.KernelRelease,
 				firstExtra,
 				kernelVersion,
 				kr.Architecture.String(),
-			),
-			fmt.Sprintf(
+			), fmt.Sprintf(
 				"%s/linux-headers-%s%s_%s-%s.%d~18.04.1_%s.deb",
 				baseURL,
 				kr.Fullversion,
@@ -353,9 +352,11 @@ func ubuntuGCCVersionFromKernelRelease(kr kernelrelease.KernelRelease) string {
 		}
 		return "6"
 	case 5:
-		if kr.PatchLevel >= 13 {
-			return "10"
-		}
+        if kr.PatchLevel >= 11 {
+            return "10"
+        } else if kr.PatchLevel >= 19 {
+            return "11"
+        }
 	}
 
 	return "8"

--- a/pkg/driverbuilder/builder/ubuntu.go
+++ b/pkg/driverbuilder/builder/ubuntu.go
@@ -353,10 +353,10 @@ func ubuntuGCCVersionFromKernelRelease(kr kernelrelease.KernelRelease) string {
 		}
 		return "6"
 	case 5:
-		if kr.PatchLevel >= 11 {
-			return "10"
-		} else if kr.PatchLevel >= 19 {
+		if kr.PatchLevel >= 19 {
 			return "11"
+		} else if kr.PatchLevel >= 11 {
+			return "10"
 		}
 	}
 

--- a/pkg/driverbuilder/builder/ubuntu.go
+++ b/pkg/driverbuilder/builder/ubuntu.go
@@ -216,7 +216,8 @@ func fetchUbuntuGenericKernelURL(baseURL string, kr kernelrelease.KernelRelease,
 				firstExtra,
 				kernelVersion,
 				kr.Architecture.String(),
-			), fmt.Sprintf(
+			),
+			fmt.Sprintf(
 				"%s/linux-headers-%s%s_%s-%s.%d~18.04.1_%s.deb",
 				baseURL,
 				kr.Fullversion,
@@ -352,11 +353,11 @@ func ubuntuGCCVersionFromKernelRelease(kr kernelrelease.KernelRelease) string {
 		}
 		return "6"
 	case 5:
-        if kr.PatchLevel >= 11 {
-            return "10"
-        } else if kr.PatchLevel >= 19 {
-            return "11"
-        }
+		if kr.PatchLevel >= 11 {
+			return "10"
+		} else if kr.PatchLevel >= 19 {
+			return "11"
+		}
 	}
 
 	return "8"


### PR DESCRIPTION
Signed-off-by: Logan Bond <lbond@secureworks.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area cmd

/area pkg

> /area docs

> /area tests


**What this PR does / why we need it**:
We are seeing build failures for ubuntu 5.11 and 5.19 kernel releases. It seems the GCC versions just need to be slightly adjusted.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
* Add gcc-11 support for 5.19
* Fix gcc-10 for 5.11
```
