### PR TITLE
fix(ubuntu-azure-usage): Fix the usage of an azure ubuntu 

### DIFF
--- a/pkg/driverbuilder/builder/ubuntu.go
+++ b/pkg/driverbuilder/builder/ubuntu.go
@@ -67,6 +67,8 @@ func (v ubuntuGeneric) Script(c Config, kr kernelrelease.KernelRelease) (string,
 
 	if kr.IsGKE() {
 		td.KernelHeadersPattern = "linux-headers*gke"
+	} else if kr.IsAzure() {
+		td.KernelHeadersPattern = "linux-headers*azure"
 	}
 
 	buf := bytes.NewBuffer(nil)

--- a/pkg/kernelrelease/kernelrelease.go
+++ b/pkg/kernelrelease/kernelrelease.go
@@ -47,6 +47,10 @@ func (kr *KernelRelease) IsGKE() bool {
 	return strings.HasSuffix(kr.Extraversion, "gke")
 }
 
+func (kr *KernelRelease) IsAzure() bool {
+	return strings.HasSuffix(kr.Extraversion, "azure")
+}
+
 // FromString extracts a KernelRelease object from string.
 func FromString(kernelVersionStr string) KernelRelease {
 	kv := KernelRelease{}


### PR DESCRIPTION
(used with ubuntu-generic and some kernelurls)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area pkg

**What this PR does / why we need it**:
The pattern used to list linux headers is too restrictive, causing the `readlink` call in the `ubuntu.sh` script to fail, when trying to build a driver for a ubuntu-azure with this test-infra/driverkit config: 
```
kernelversion: 46
kernelrelease: 5.4.0-1044-azure
target: ubuntu-generic
architecture: amd64
output:
  module: output/39ae7d40496793cf3d3e7890c9bbdc202263836b/falco_ubuntu-generic_5.4.0-1044-azure_46.ko
  probe: output/39ae7d40496793cf3d3e7890c9bbdc202263836b/falco_ubuntu-generic_5.4.0-1044-azure_46.o
kernelurls: ["http://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-azure/linux-azure-headers-5.4.0-1044_5.4.0-1044.46_all.deb","http://security.ubuntu.com/ubuntu/pool/main/l/linux-azure/linux-azure-headers-5.4.0-1044_5.4.0-1044.46_all.deb","http://security.ubuntu.com/ubuntu/pool/main/l/linux-azure/linux-headers-5.4.0-1044-azure_5.4.0-1044.46_amd64.deb","http://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-azure/linux-headers-5.4.0-1044-azure_5.4.0-1044.46_amd64.deb"]
```

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->
None

**Special notes for your reviewer**:
I've been trying to find a solution to build driver for azure's ubuntu since a week now and I'm facing many difficulties. I'm trying to build it with falcosecurity/test-infra, but all configs with azure use the target 'ubuntu-azure' while `driverkit` do not accept it, so it exit. So I tried with the generic one and faced a crash, fixed by this PR.
