### PR TITLE
update(OWNERS): move inactive approvers to emeritus_approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,10 +1,6 @@
 approvers:
-  - fntlnz
   - leodido
   - dwindsor
   - fededp
-reviewers:
+emeritus_approvers:
   - fntlnz
-  - leodido
-  - dwindsor
-  - fededp


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**Any specific area of the project related to this PR?**

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Supersedes #179 and #182, see https://github.com/falcosecurity/driverkit/pull/179#issuecomment-1184191306 and https://github.com/falcosecurity/driverkit/pull/182#issuecomment-1190017187. Additionally, this fixes the OWNERS files by removing duplicates in the `approvers` and `reviewers` sections.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
