### PR TITLE
new: multiple builders

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,8 @@ jobs:
           name: Test
           command: make test
       - run:
-          name: Integration tests # test cross build too!
-          command: make -e TARGET_TEST_ARCH=* integration_test
+          name: Integration tests
+          command: make integration_test
       - run:
           name: Prepare Artifacts
           command: |

--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,7 @@ manifest/latest:
 
 .PHONY: test
 test:
+	go clean -testcache
 	go test -v -cover -race ./...
 	go test -v -cover -buildmode=pie ./cmd
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ ifeq ($(COMMITS_FROM_GIT_TAG),0)
 	endif
 endif
 
-DOCKER_ORG ?= falcosecurity
+DOCKER_ORG ?= fededp
 
 BUILDERS := $(patsubst build/builder_%.Dockerfile,%,$(wildcard build/builder_*.Dockerfile))
 
@@ -32,7 +32,7 @@ IMAGE_NAME_DRIVERKIT_REF := $(IMAGE_NAME_DRIVERKIT):$(GIT_REF)_$(shell uname -m)
 IMAGE_NAME_DRIVERKIT_COMMIT := $(IMAGE_NAME_DRIVERKIT):$(GIT_COMMIT)_$(shell uname -m)
 IMAGE_NAME_DRIVERKIT_LATEST := $(IMAGE_NAME_DRIVERKIT):latest_$(shell uname -m)
 
-LDFLAGS := -X github.com/falcosecurity/driverkit/pkg/version.buildTime=$(shell date +%s) -X github.com/falcosecurity/driverkit/pkg/version.gitCommit=${GIT_COMMIT} -X github.com/falcosecurity/driverkit/pkg/version.gitTag=$(if ${GIT_TAG},${GIT_TAG},v0.0.0) -X github.com/falcosecurity/driverkit/pkg/version.commitsFromGitTag=${COMMITS_FROM_GIT_TAG} -X github.com/falcosecurity/driverkit/pkg/builder.BaseImage=${IMAGE_NAME_BUILDER_BASE}:$(GIT_COMMIT)
+LDFLAGS := -X github.com/falcosecurity/driverkit/pkg/version.buildTime=$(shell date +%s) -X github.com/falcosecurity/driverkit/pkg/version.gitCommit=${GIT_COMMIT} -X github.com/falcosecurity/driverkit/pkg/version.gitTag=$(if ${GIT_TAG},${GIT_TAG},v0.0.0) -X github.com/falcosecurity/driverkit/pkg/version.commitsFromGitTag=${COMMITS_FROM_GIT_TAG} -X github.com/falcosecurity/driverkit/pkg/driverbuilder/builder.BaseImage=${IMAGE_NAME_BUILDER_BASE}:$(GIT_COMMIT)
 
 TARGET_TEST_ARCH ?= $(shell uname -m)
 test_configs := $(wildcard test/$(TARGET_TEST_ARCH)/configs/*.yaml)

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ ifeq ($(COMMITS_FROM_GIT_TAG),0)
 	endif
 endif
 
-DOCKER_ORG ?= fededp
+DOCKER_ORG ?= falcosecurity
 
 BUILDERS := $(patsubst build/builder_%.Dockerfile,%,$(wildcard build/builder_*.Dockerfile))
 

--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,13 @@ endif
 
 DOCKER_ORG ?= falcosecurity
 
-IMAGE_NAME_BUILDER ?= docker.io/$(DOCKER_ORG)/driverkit-builder
+BUILDERS := $(patsubst build/builder_%.Dockerfile,%,$(wildcard build/builder_*.Dockerfile))
 
-IMAGE_NAME_BUILDER_REF := $(IMAGE_NAME_BUILDER):$(GIT_REF)_$(shell uname -m)
-IMAGE_NAME_BUILDER_COMMIT := $(IMAGE_NAME_BUILDER):$(GIT_COMMIT)_$(shell uname -m)
-IMAGE_NAME_BUILDER_LATEST := $(IMAGE_NAME_BUILDER):latest_$(shell uname -m)
+IMAGE_NAME_BUILDER_BASE ?= docker.io/$(DOCKER_ORG)/driverkit-builder
+
+IMAGE_NAME_SUFFIX_REF := ":$(GIT_REF)_$(shell uname -m)"
+IMAGE_NAME_SUFFIX_COMMIT := ":$(GIT_COMMIT)_$(shell uname -m)"
+IMAGE_NAME_SUFFIX_LATEST := ":latest_$(shell uname -m)"
 
 IMAGE_NAME_DRIVERKIT ?= docker.io/$(DOCKER_ORG)/driverkit
 
@@ -30,7 +32,7 @@ IMAGE_NAME_DRIVERKIT_REF := $(IMAGE_NAME_DRIVERKIT):$(GIT_REF)_$(shell uname -m)
 IMAGE_NAME_DRIVERKIT_COMMIT := $(IMAGE_NAME_DRIVERKIT):$(GIT_COMMIT)_$(shell uname -m)
 IMAGE_NAME_DRIVERKIT_LATEST := $(IMAGE_NAME_DRIVERKIT):latest_$(shell uname -m)
 
-LDFLAGS := -X github.com/falcosecurity/driverkit/pkg/version.buildTime=$(shell date +%s) -X github.com/falcosecurity/driverkit/pkg/version.gitCommit=${GIT_COMMIT} -X github.com/falcosecurity/driverkit/pkg/version.gitTag=$(if ${GIT_TAG},${GIT_TAG},v0.0.0) -X github.com/falcosecurity/driverkit/pkg/version.commitsFromGitTag=${COMMITS_FROM_GIT_TAG} -X github.com/falcosecurity/driverkit/pkg/driverbuilder.BuilderBaseImage=$(IMAGE_NAME_BUILDER):$(GIT_COMMIT)
+LDFLAGS := -X github.com/falcosecurity/driverkit/pkg/version.buildTime=$(shell date +%s) -X github.com/falcosecurity/driverkit/pkg/version.gitCommit=${GIT_COMMIT} -X github.com/falcosecurity/driverkit/pkg/version.gitTag=$(if ${GIT_TAG},${GIT_TAG},v0.0.0) -X github.com/falcosecurity/driverkit/pkg/version.commitsFromGitTag=${COMMITS_FROM_GIT_TAG} -X github.com/falcosecurity/driverkit/pkg/builder.BaseImage=${IMAGE_NAME_BUILDER_BASE}:$(GIT_COMMIT)
 
 TARGET_TEST_ARCH ?= $(shell uname -m)
 test_configs := $(wildcard test/$(TARGET_TEST_ARCH)/configs/*.yaml)
@@ -57,7 +59,9 @@ image/all: image/builder image/driverkit
 
 .PHONY: image/builder
 image/builder:
-	$(DOCKER) buildx build -o type=image,push="false" -f build/builder.Dockerfile .
+	$(foreach b,$(BUILDERS),\
+		$(DOCKER) buildx build -o type=image,push="false" -f build/builder_$b.Dockerfile . ; \
+    )
 
 .PHONY: image/driverkit
 image/driverkit:
@@ -67,7 +71,9 @@ push/all: push/builder push/driverkit
 
 .PHONY: push/builder
 push/builder:
-	$(DOCKER) buildx build --push -t "$(IMAGE_NAME_BUILDER_REF)" -t "$(IMAGE_NAME_BUILDER_COMMIT)" -f build/builder.Dockerfile .
+	$(foreach b,$(BUILDERS),\
+		$(DOCKER) buildx build --push -t "$(IMAGE_NAME_BUILDER_BASE)_$b$(IMAGE_NAME_SUFFIX_REF)" -t "$(IMAGE_NAME_BUILDER_BASE)_$b$(IMAGE_NAME_SUFFIX_COMMIT)" -f build/builder_$b.Dockerfile . ; \
+	)
 
 .PHONY: push/driverkit
 push/driverkit:
@@ -75,17 +81,21 @@ push/driverkit:
 
 .PHONY: push/latest
 push/latest:
-	$(DOCKER) buildx build --push -t "$(IMAGE_NAME_BUILDER_LATEST)" -f build/builder.Dockerfile .
+	$(foreach b,$(BUILDERS),\
+		$(DOCKER) buildx build --push -t "$(IMAGE_NAME_BUILDER_BASE)_$b$(IMAGE_NAME_SUFFIX_LATEST)" -f build/builder_$b.Dockerfile . ; \
+	)
 	$(DOCKER) buildx build --push -t "$(IMAGE_NAME_DRIVERKIT_LATEST)" -f build/driverkit.Dockerfile .
 
 manifest/all: manifest/builder manifest/driverkit
 
 .PHONY: manifest/builder
 manifest/builder:
-	$(DOCKER) manifest create $(IMAGE_NAME_BUILDER):$(GIT_REF) $(IMAGE_NAME_BUILDER):$(GIT_REF)_x86_64 $(IMAGE_NAME_BUILDER):$(GIT_REF)_aarch64
-	$(DOCKER) manifest push $(IMAGE_NAME_BUILDER):$(GIT_REF)
-	$(DOCKER) manifest create $(IMAGE_NAME_BUILDER):$(GIT_COMMIT) $(IMAGE_NAME_BUILDER):$(GIT_COMMIT)_x86_64 $(IMAGE_NAME_BUILDER):$(GIT_COMMIT)_aarch64
-	$(DOCKER) manifest push $(IMAGE_NAME_BUILDER):$(GIT_COMMIT)
+	$(foreach b,$(BUILDERS),\
+		$(DOCKER) manifest create "$(IMAGE_NAME_BUILDER_BASE)_$b:$(GIT_REF)" $(IMAGE_NAME_BUILDER_BASE)_$b:$(GIT_REF)_x86_64 $(IMAGE_NAME_BUILDER_BASE)_$b:$(GIT_REF)_aarch64 ; \
+		$(DOCKER) manifest push "$(IMAGE_NAME_BUILDER_BASE)_$b:$(GIT_REF)" ; \
+		$(DOCKER) manifest create $(IMAGE_NAME_BUILDER_BASE)_$b:$(GIT_COMMIT) $(IMAGE_NAME_BUILDER_BASE)_$b:$(GIT_COMMIT)_x86_64 $(IMAGE_NAME_BUILDER_BASE)_$b:$(GIT_COMMIT)_aarch64 ; \
+		$(DOCKER) manifest push $(IMAGE_NAME_BUILDER_BASE)_$b:$(GIT_COMMIT) ; \
+	)
 
 .PHONY: manifest/driverkit
 manifest/driverkit:
@@ -96,8 +106,10 @@ manifest/driverkit:
 
 .PHONY: manifest/latest
 manifest/latest:
-	$(DOCKER) manifest create $(IMAGE_NAME_BUILDER):latest $(IMAGE_NAME_BUILDER):latest_x86_64 $(IMAGE_NAME_BUILDER):latest_aarch64
-	$(DOCKER) manifest push $(IMAGE_NAME_BUILDER):latest
+	$(foreach b,$(BUILDERS),\
+	  	$(DOCKER) manifest create "$(IMAGE_NAME_BUILDER_BASE)_$b:latest" $(IMAGE_NAME_BUILDER_BASE)_$b:latest_x86_64 $(IMAGE_NAME_BUILDER_BASE)_$b:latest_aarch64 ; \
+		$(DOCKER) manifest push "$(IMAGE_NAME_BUILDER_BASE)_$b:latest" ; \
+	)
 	$(DOCKER) manifest create $(IMAGE_NAME_DRIVERKIT):latest $(IMAGE_NAME_DRIVERKIT):latest_x86_64 $(IMAGE_NAME_DRIVERKIT):latest_aarch64
 	$(DOCKER) manifest push $(IMAGE_NAME_DRIVERKIT):latest
 
@@ -111,7 +123,7 @@ integration_test: $(test_configs)
 
 .PHONY: $(test_configs)
 $(test_configs): ${driverkit}
-	${driverkit} docker -c $@ --builderimage falcosecurity/driverkit-builder:latest -l debug --timeout 600
+	${driverkit} docker -c $@ --builderimage auto:latest -l debug --timeout 600
 
 .PHONY: ${driverkit_docgen}
 ${driverkit_docgen}: ${PWD}/docgen

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ that allows to specify a list of headers.
 
 A solution to crawl all supported kernels by multiple distro was recently developed,  
 and it provides a json output with aforementioned `kernelheaders`: https://github.com/falcosecurity/kernel-crawler.  
-Json for supported architectures can be found at https://github.com/falcosecurity/kernel-crawler/tree/main/kernels.
+Json for supported architectures can be found at https://falcosecurity.github.io/kernel-crawler/.
 
 ## How to use
 
@@ -103,7 +103,11 @@ For a comprehensive list of examples, heads to [example configs](Example_configs
 ## Support a new target
 
 To add support for a new target, a new builder must be added.  
-For more info, you can find specific docs under [pkg/driverbuilder/builder](/pkg/driverbuilder/builder) README file.
+For more info, you can find specific docs in [docs/builder.md](docs/builder.md) file.
+
+## Support a new builder image
+
+To add support for a new builder image, follow the doc at [docs/builder_images.md](docs/builder_images.md) file.
 
 ## Survey
 

--- a/build/builder_bookworm.Dockerfile
+++ b/build/builder_bookworm.Dockerfile
@@ -1,0 +1,42 @@
+FROM debian:bookworm
+
+LABEL maintainer="cncf-falco-dev@lists.cncf.io"
+
+ARG TARGETARCH
+
+RUN cp /etc/skel/.bashrc /root && cp /etc/skel/.profile /root
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+	bash-completion \
+	bc \
+	clang \
+    llvm \
+	ca-certificates \
+	curl \
+	dkms \
+	dwarves \
+	gnupg2 \
+	gcc \
+    gcc-11 \
+	jq \
+	libc6-dev \
+	libelf-dev \
+	netcat-openbsd \
+	xz-utils \
+	rpm2cpio \
+	cpio \
+	flex \
+	bison \
+	openssl \
+	libssl-dev \
+	libncurses-dev \
+	libudev-dev \
+	libpci-dev \
+	libiberty-dev \
+	lsb-release \
+	wget \
+	software-properties-common \
+	gpg \
+	zstd \
+    && rm -rf /var/lib/apt/lists/*

--- a/build/builder_bullseye.Dockerfile
+++ b/build/builder_bullseye.Dockerfile
@@ -1,0 +1,42 @@
+FROM debian:bullseye
+
+LABEL maintainer="cncf-falco-dev@lists.cncf.io"
+
+ARG TARGETARCH
+
+RUN cp /etc/skel/.bashrc /root && cp /etc/skel/.profile /root
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+	bash-completion \
+	bc \
+	clang \
+    llvm \
+	ca-certificates \
+	curl \
+	dkms \
+	dwarves \
+	gnupg2 \
+	gcc \
+    gcc-9 \
+	jq \
+	libc6-dev \
+	libelf-dev \
+	netcat \
+	xz-utils \
+	rpm2cpio \
+	cpio \
+	flex \
+	bison \
+	openssl \
+	libssl-dev \
+	libncurses-dev \
+	libudev-dev \
+	libpci-dev \
+	libiberty-dev \
+	lsb-release \
+	wget \
+	software-properties-common \
+	gpg \
+	zstd \
+    && rm -rf /var/lib/apt/lists/*

--- a/build/builder_buster.Dockerfile
+++ b/build/builder_buster.Dockerfile
@@ -11,7 +11,8 @@ RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
 	bash-completion \
 	bc \
-	clang-7 \
+	clang \
+    llvm \
 	ca-certificates \
 	curl \
 	dkms \
@@ -21,7 +22,6 @@ RUN apt-get update \
 	jq \
 	libc6-dev \
 	libelf-dev \
-	llvm-7 \
 	netcat \
 	xz-utils \
 	rpm2cpio \
@@ -42,12 +42,6 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 RUN if [ "$TARGETARCH" = "amd64" ] ; then apt-get install -y --no-install-recommends libmpx2; fi
-
-# Install clang 12
-RUN cd /tmp \
-	&& wget https://apt.llvm.org/llvm.sh \
-	&& chmod +x llvm.sh \
-	&& ./llvm.sh 12
 
 # gcc 6 is no longer included in debian stable, but we need it to
 # build kernel modules on the default debian-based ami used by

--- a/build/builder_buster.Dockerfile
+++ b/build/builder_buster.Dockerfile
@@ -6,9 +6,16 @@ ARG TARGETARCH
 
 RUN cp /etc/skel/.bashrc /root && cp /etc/skel/.profile /root
 RUN echo 'deb http://deb.debian.org/debian buster-backports main' >>/etc/apt/sources.list
+RUN echo 'deb http://deb.debian.org/debian jessie main' >>/etc/apt/sources.list # gcc 4.9
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+# jessie repo is unsigned therefore the APT options
+RUN apt-get \
+	-o Acquire::AllowInsecureRepositories=true \
+	-o Acquire::AllowDowngradeToInsecureRepositories=true \
+	update \
+	&& apt-get \
+	-o APT::Get::AllowUnauthenticated=true \
+	install -y --no-install-recommends \
 	bash-completion \
 	bc \
 	clang \
@@ -19,6 +26,7 @@ RUN apt-get update \
 	dwarves/buster-backports \
 	gnupg2 \
 	gcc \
+	gcc-4.9 \
 	jq \
 	libc6-dev \
 	libelf-dev \

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -144,6 +144,8 @@ func NewRootCmd() *RootCmd {
 	flags.StringVar(&rootOpts.ModuleDeviceName, "moduledevicename", rootOpts.ModuleDeviceName, "kernel module device name (the default is falco, so the device will be under /dev/falco*)")
 	flags.StringVar(&rootOpts.ModuleDriverName, "moduledrivername", rootOpts.ModuleDriverName, "kernel module driver name, i.e. the name you see when you check installed modules via lsmod")
 	flags.StringVar(&rootOpts.BuilderImage, "builderimage", rootOpts.BuilderImage, "docker image to be used to build the kernel module and eBPF probe. If not provided, an automatically selected image will be used.")
+	flags.Float64Var(&rootOpts.GCCVersion, "gccversion", rootOpts.GCCVersion, "enforce a specific gcc version for the build")
+
 	flags.StringSliceVar(&rootOpts.KernelUrls, "kernelurls", nil, "list of kernel header urls (e.g. --kernelurls <URL1> --kernelurls <URL2> --kernelurls \"<URL3>,<URL4>\")")
 
 	viper.BindPFlags(flags)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -143,7 +143,7 @@ func NewRootCmd() *RootCmd {
 	flags.StringVar(&rootOpts.KernelConfigData, "kernelconfigdata", rootOpts.KernelConfigData, "base64 encoded kernel config data: in some systems it can be found under the /boot directory, in other it is gzip compressed under /proc")
 	flags.StringVar(&rootOpts.ModuleDeviceName, "moduledevicename", rootOpts.ModuleDeviceName, "kernel module device name (the default is falco, so the device will be under /dev/falco*)")
 	flags.StringVar(&rootOpts.ModuleDriverName, "moduledrivername", rootOpts.ModuleDriverName, "kernel module driver name, i.e. the name you see when you check installed modules via lsmod")
-	flags.StringVar(&rootOpts.BuilderImage, "builderimage", rootOpts.BuilderImage, "docker image to be used to build the kernel module and eBPF probe. If not provided, the default image will be used.")
+	flags.StringVar(&rootOpts.BuilderImage, "builderimage", rootOpts.BuilderImage, "docker image to be used to build the kernel module and eBPF probe. If not provided, an automatically selected image will be used.")
 	flags.StringSliceVar(&rootOpts.KernelUrls, "kernelurls", nil, "list of kernel header urls (e.g. --kernelurls <URL1> --kernelurls <URL2> --kernelurls \"<URL3>,<URL4>\")")
 
 	viper.BindPFlags(flags)

--- a/cmd/root_options.go
+++ b/cmd/root_options.go
@@ -26,6 +26,7 @@ type RootOptions struct {
 	Target           string   `validate:"required,target" name:"target"`
 	KernelConfigData string   `validate:"omitempty,base64" name:"kernel config data"` // fixme > tag "name" does not seem to work when used at struct level, but works when used at inner level
 	BuilderImage     string   `validate:"imagename" name:"builder image"`
+	GCCVersion       float64  `name:"gcc version"`
 	KernelUrls       []string `name:"kernel header urls"`
 	Output           OutputOptions
 }
@@ -106,6 +107,7 @@ func (ro *RootOptions) toBuild() *builder.Build {
 		ProbeFilePath:      ro.Output.Probe,
 		ModuleDriverName:   ro.ModuleDriverName,
 		ModuleDeviceName:   ro.ModuleDeviceName,
+		GCCVersion:         ro.GCCVersion,
 		CustomBuilderImage: ro.BuilderImage,
 		KernelUrls:         ro.KernelUrls,
 	}

--- a/cmd/root_options.go
+++ b/cmd/root_options.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"github.com/creasty/defaults"
-	"github.com/falcosecurity/driverkit/pkg/driverbuilder"
 	"github.com/falcosecurity/driverkit/pkg/driverbuilder/builder"
 	"github.com/falcosecurity/driverkit/validate"
 	"github.com/go-playground/validator/v10"
@@ -37,7 +36,7 @@ func init() {
 
 func (ro *RootOptions) SetDefaults() {
 	if defaults.CanUpdate(ro.BuilderImage) {
-		ro.BuilderImage = driverbuilder.BuilderBaseImage
+		ro.BuilderImage = builder.BaseImage
 	}
 }
 
@@ -133,7 +132,7 @@ func RootOptionsLevelValidation(level validator.StructLevel) {
 	}
 
 	// Target redhat requires a valid build image (has to be registered in order to download packages)
-	if opts.Target == builder.TargetTypeRedhat.String() && opts.BuilderImage == driverbuilder.BuilderBaseImage {
+	if opts.Target == builder.TargetTypeRedhat.String() && opts.BuilderImage == builder.BaseImage {
 		level.ReportError(opts.BuilderImage, "builderimage", "builderimage", "required_builderimage_with_target_redhat", "")
 	}
 }

--- a/cmd/root_options.go
+++ b/cmd/root_options.go
@@ -34,12 +34,6 @@ func init() {
 	validate.V.RegisterStructValidation(RootOptionsLevelValidation, RootOptions{})
 }
 
-func (ro *RootOptions) SetDefaults() {
-	if defaults.CanUpdate(ro.BuilderImage) {
-		ro.BuilderImage = builder.BaseImage
-	}
-}
-
 // NewRootOptions ...
 func NewRootOptions() *RootOptions {
 	rootOpts := &RootOptions{}
@@ -132,7 +126,7 @@ func RootOptionsLevelValidation(level validator.StructLevel) {
 	}
 
 	// Target redhat requires a valid build image (has to be registered in order to download packages)
-	if opts.Target == builder.TargetTypeRedhat.String() && opts.BuilderImage == builder.BaseImage {
+	if opts.Target == builder.TargetTypeRedhat.String() && opts.BuilderImage == "" {
 		level.ReportError(opts.BuilderImage, "builderimage", "builderimage", "required_builderimage_with_target_redhat", "")
 	}
 }

--- a/cmd/testdata/templates/flags.txt
+++ b/cmd/testdata/templates/flags.txt
@@ -4,6 +4,7 @@ Flags:
   -c, --config string             config file path (default $HOME/.driverkit.yaml if exists)
       --driverversion string      driver version as a git commit hash or as a git tag (default "master")
       --dryrun                    do not actually perform the action
+      --gccversion float          enforce a specific gcc version for the build
   -h, --help                      help for {{ .Cmd }}
       --kernelconfigdata string   base64 encoded kernel config data: in some systems it can be found under the /boot directory, in other it is gzip compressed under /proc
       --kernelrelease string      kernel release to build the module for, it can be found by executing 'uname -v'

--- a/cmd/testdata/templates/flags.txt
+++ b/cmd/testdata/templates/flags.txt
@@ -1,6 +1,6 @@
 Flags:
       --architecture string       target architecture for the built driver, one of {{ .Architectures }} (default "{{ .CurrentArch }}")
-      --builderimage string       docker image to be used to build the kernel module and eBPF probe. If not provided, the default image will be used. (default "falcosecurity/driverkit-builder:latest")
+      --builderimage string       docker image to be used to build the kernel module and eBPF probe. If not provided, an automatically selected image will be used.
   -c, --config string             config file path (default $HOME/.driverkit.yaml if exists)
       --driverversion string      driver version as a git commit hash or as a git tag (default "master")
       --dryrun                    do not actually perform the action

--- a/docs/builder_images.md
+++ b/docs/builder_images.md
@@ -1,0 +1,34 @@
+# Builder Images
+
+Driverkit supports multiple builder images.  
+A builder image is the docker image used to build the drivers.
+
+## Adding a builder image
+
+Adding a builder image is just a matter of adding a new dockerfile under the [build](../build) folder,  
+with a name matching: `builder_$osname.Dockerfile` (like: `builder_stretch.Dockerfile`).  
+
+The makefile will be then automatically able to collect the new docker images and pushing it as part of the CI.  
+
+Moreover, the new image $osname must also be added to the static map of images, kept in [builders.go source file](../pkg/driverbuilder/builder/builders.go):  
+```go
+var images = map[string]Image{
+	"buster": {
+		GCCVersion: []float64{4.8, 5, 6, 8},
+	},
+	"bullseye": {
+		GCCVersion: []float64{9, 10},
+	},
+	"bookworm": {
+		GCCVersion: []float64{11, 12},
+	},
+	"stretch": {
+        GCCVersion: []float64{6},
+    },
+}
+```
+
+Then, the new image's shipped gcc is now available to various builder using the `defaultGCC` method's algorithm,  
+or chosen by each builder by implementing the `builder.GCCVersionRequestor` interface.  
+
+Finally, the [builder](builder.md) doc file should be updated with the new available GCC (section 3.).

--- a/docs/driverkit.md
+++ b/docs/driverkit.md
@@ -10,7 +10,7 @@ driverkit
 
 ```
       --architecture string       target architecture for the built driver, one of [amd64,arm64] (default "amd64")
-      --builderimage string       docker image to be used to build the kernel module and eBPF probe. If not provided, the default image will be used. (default "falcosecurity/driverkit-builder:latest")
+      --builderimage string       docker image to be used to build the kernel module and eBPF probe. If not provided, an automatically selected image will be used.
   -c, --config string             config file path (default $HOME/.driverkit.yaml if exists)
       --driverversion string      driver version as a git commit hash or as a git tag (default "master")
       --dryrun                    do not actually perform the action

--- a/docs/driverkit.md
+++ b/docs/driverkit.md
@@ -14,6 +14,7 @@ driverkit
   -c, --config string             config file path (default $HOME/.driverkit.yaml if exists)
       --driverversion string      driver version as a git commit hash or as a git tag (default "master")
       --dryrun                    do not actually perform the action
+      --gccversion float          enforce a specific gcc version for the build
   -h, --help                      help for driverkit
       --kernelconfigdata string   base64 encoded kernel config data: in some systems it can be found under the /boot directory, in other it is gzip compressed under /proc
       --kernelrelease string      kernel release to build the module for, it can be found by executing 'uname -v'

--- a/docs/driverkit.md
+++ b/docs/driverkit.md
@@ -6,30 +6,6 @@ A command line tool to build Falco kernel modules and eBPF probes.
 driverkit
 ```
 
-### Options
-
-```
-      --architecture string       target architecture for the built driver, one of [amd64,arm64] (default "amd64")
-      --builderimage string       docker image to be used to build the kernel module and eBPF probe. If not provided, an automatically selected image will be used.
-  -c, --config string             config file path (default $HOME/.driverkit.yaml if exists)
-      --driverversion string      driver version as a git commit hash or as a git tag (default "master")
-      --dryrun                    do not actually perform the action
-      --gccversion float          enforce a specific gcc version for the build
-  -h, --help                      help for driverkit
-      --kernelconfigdata string   base64 encoded kernel config data: in some systems it can be found under the /boot directory, in other it is gzip compressed under /proc
-      --kernelrelease string      kernel release to build the module for, it can be found by executing 'uname -v'
-      --kernelurls strings        list of kernel header urls (e.g. --kernelurls <URL1> --kernelurls <URL2> --kernelurls "<URL3>,<URL4>")
-      --kernelversion string      kernel version to build the module for, it's the numeric value after the hash when you execute 'uname -v' (default "1")
-  -l, --loglevel string           log level (default "info")
-      --moduledevicename string   kernel module device name (the default is falco, so the device will be under /dev/falco*) (default "falco")
-      --moduledrivername string   kernel module driver name, i.e. the name you see when you check installed modules via lsmod (default "falco")
-      --output-module string      filepath where to save the resulting kernel module
-      --output-probe string       filepath where to save the resulting eBPF probe
-      --proxy string              the proxy to use to download data
-  -t, --target string             the system to target the build for, one of [amazonlinux,amazonlinux2,amazonlinux2022,archlinux,centos,debian,flatcar,minikube,photon,redhat,rocky,ubuntu,ubuntu-aws,ubuntu-generic,vanilla]
-      --timeout int               timeout in seconds (default 120)
-```
-
 ### SEE ALSO
 
 * [driverkit completion](driverkit_completion.md)	 - Generates completion scripts.

--- a/docs/driverkit_docker.md
+++ b/docs/driverkit_docker.md
@@ -6,30 +6,6 @@ Build Falco kernel modules and eBPF probes against a docker daemon.
 driverkit docker [flags]
 ```
 
-### Options
-
-```
-      --architecture string       target architecture for the built driver, one of [amd64,arm64] (default "amd64")
-      --builderimage string       docker image to be used to build the kernel module and eBPF probe. If not provided, an automatically selected image will be used.
-  -c, --config string             config file path (default $HOME/.driverkit.yaml if exists)
-      --driverversion string      driver version as a git commit hash or as a git tag (default "master")
-      --dryrun                    do not actually perform the action
-      --gccversion float          enforce a specific gcc version for the build
-  -h, --help                      help for docker
-      --kernelconfigdata string   base64 encoded kernel config data: in some systems it can be found under the /boot directory, in other it is gzip compressed under /proc
-      --kernelrelease string      kernel release to build the module for, it can be found by executing 'uname -v'
-      --kernelurls strings        list of kernel header urls (e.g. --kernelurls <URL1> --kernelurls <URL2> --kernelurls "<URL3>,<URL4>")
-      --kernelversion string      kernel version to build the module for, it's the numeric value after the hash when you execute 'uname -v' (default "1")
-  -l, --loglevel string           log level (default "info")
-      --moduledevicename string   kernel module device name (the default is falco, so the device will be under /dev/falco*) (default "falco")
-      --moduledrivername string   kernel module driver name, i.e. the name you see when you check installed modules via lsmod (default "falco")
-      --output-module string      filepath where to save the resulting kernel module
-      --output-probe string       filepath where to save the resulting eBPF probe
-      --proxy string              the proxy to use to download data
-  -t, --target string             the system to target the build for, one of [amazonlinux,amazonlinux2,amazonlinux2022,archlinux,centos,debian,flatcar,minikube,photon,redhat,rocky,ubuntu,ubuntu-aws,ubuntu-generic,vanilla]
-      --timeout int               timeout in seconds (default 120)
-```
-
 ### SEE ALSO
 
 * [driverkit](driverkit.md)	 - A command line tool to build Falco kernel modules and eBPF probes.

--- a/docs/driverkit_docker.md
+++ b/docs/driverkit_docker.md
@@ -10,7 +10,7 @@ driverkit docker [flags]
 
 ```
       --architecture string       target architecture for the built driver, one of [amd64,arm64] (default "amd64")
-      --builderimage string       docker image to be used to build the kernel module and eBPF probe. If not provided, the default image will be used. (default "falcosecurity/driverkit-builder:latest")
+      --builderimage string       docker image to be used to build the kernel module and eBPF probe. If not provided, an automatically selected image will be used.
   -c, --config string             config file path (default $HOME/.driverkit.yaml if exists)
       --driverversion string      driver version as a git commit hash or as a git tag (default "master")
       --dryrun                    do not actually perform the action

--- a/docs/driverkit_docker.md
+++ b/docs/driverkit_docker.md
@@ -14,6 +14,7 @@ driverkit docker [flags]
   -c, --config string             config file path (default $HOME/.driverkit.yaml if exists)
       --driverversion string      driver version as a git commit hash or as a git tag (default "master")
       --dryrun                    do not actually perform the action
+      --gccversion float          enforce a specific gcc version for the build
   -h, --help                      help for docker
       --kernelconfigdata string   base64 encoded kernel config data: in some systems it can be found under the /boot directory, in other it is gzip compressed under /proc
       --kernelrelease string      kernel release to build the module for, it can be found by executing 'uname -v'

--- a/docs/driverkit_kubernetes-in-cluster.md
+++ b/docs/driverkit_kubernetes-in-cluster.md
@@ -10,7 +10,7 @@ driverkit kubernetes-in-cluster [flags]
 
 ```
       --architecture string        target architecture for the built driver, one of [amd64,arm64] (default "amd64")
-      --builderimage string        docker image to be used to build the kernel module and eBPF probe. If not provided, the default image will be used. (default "falcosecurity/driverkit-builder:latest")
+      --builderimage string        docker image to be used to build the kernel module and eBPF probe. If not provided, an automatically selected image will be used.
   -c, --config string              config file path (default $HOME/.driverkit.yaml if exists)
       --driverversion string       driver version as a git commit hash or as a git tag (default "master")
       --dryrun                     do not actually perform the action

--- a/docs/driverkit_kubernetes-in-cluster.md
+++ b/docs/driverkit_kubernetes-in-cluster.md
@@ -6,33 +6,6 @@ Build Falco kernel modules and eBPF probes against a Kubernetes cluster inside a
 driverkit kubernetes-in-cluster [flags]
 ```
 
-### Options
-
-```
-      --architecture string        target architecture for the built driver, one of [amd64,arm64] (default "amd64")
-      --builderimage string        docker image to be used to build the kernel module and eBPF probe. If not provided, an automatically selected image will be used.
-  -c, --config string              config file path (default $HOME/.driverkit.yaml if exists)
-      --driverversion string       driver version as a git commit hash or as a git tag (default "master")
-      --dryrun                     do not actually perform the action
-      --gccversion float          enforce a specific gcc version for the build
-  -h, --help                       help for kubernetes-in-cluster
-      --image-pull-secret string   ImagePullSecret
-      --kernelconfigdata string    base64 encoded kernel config data: in some systems it can be found under the /boot directory, in other it is gzip compressed under /proc
-      --kernelrelease string       kernel release to build the module for, it can be found by executing 'uname -v'
-      --kernelurls strings         list of kernel header urls (e.g. --kernelurls <URL1> --kernelurls <URL2> --kernelurls "<URL3>,<URL4>")
-      --kernelversion string       kernel version to build the module for, it's the numeric value after the hash when you execute 'uname -v' (default "1")
-  -l, --loglevel string            log level (default "info")
-      --moduledevicename string    kernel module device name (the default is falco, so the device will be under /dev/falco*) (default "falco")
-      --moduledrivername string    kernel module driver name, i.e. the name you see when you check installed modules via lsmod (default "falco")
-  -n, --namespace string           If present, the namespace scope for the pods and its config  (default "default")
-      --output-module string       filepath where to save the resulting kernel module
-      --output-probe string        filepath where to save the resulting eBPF probe
-      --proxy string               the proxy to use to download data
-      --run-as-user int            Pods runner user
-  -t, --target string              the system to target the build for, one of [amazonlinux,amazonlinux2,amazonlinux2022,archlinux,centos,debian,flatcar,minikube,photon,redhat,rocky,ubuntu,ubuntu-aws,ubuntu-generic,vanilla]
-      --timeout int                timeout in seconds (default 120)
-```
-
 ### SEE ALSO
 
 * [driverkit](driverkit.md)	 - A command line tool to build Falco kernel modules and eBPF probes.

--- a/docs/driverkit_kubernetes-in-cluster.md
+++ b/docs/driverkit_kubernetes-in-cluster.md
@@ -14,6 +14,7 @@ driverkit kubernetes-in-cluster [flags]
   -c, --config string              config file path (default $HOME/.driverkit.yaml if exists)
       --driverversion string       driver version as a git commit hash or as a git tag (default "master")
       --dryrun                     do not actually perform the action
+      --gccversion float          enforce a specific gcc version for the build
   -h, --help                       help for kubernetes-in-cluster
       --image-pull-secret string   ImagePullSecret
       --kernelconfigdata string    base64 encoded kernel config data: in some systems it can be found under the /boot directory, in other it is gzip compressed under /proc

--- a/docs/driverkit_kubernetes.md
+++ b/docs/driverkit_kubernetes.md
@@ -23,6 +23,7 @@ driverkit kubernetes [flags]
       --context string                 the name of the kubeconfig context to use
       --driverversion string           driver version as a git commit hash or as a git tag (default "master")
       --dryrun                         do not actually perform the action
+      --gccversion float          enforce a specific gcc version for the build
   -h, --help                           help for kubernetes
       --image-pull-secret string       ImagePullSecret
       --insecure-skip-tls-verify       if true, the server's certificate will not be checked for validity, this will make your HTTPS connections insecure

--- a/docs/driverkit_kubernetes.md
+++ b/docs/driverkit_kubernetes.md
@@ -6,49 +6,6 @@ Build Falco kernel modules and eBPF probes against a Kubernetes cluster.
 driverkit kubernetes [flags]
 ```
 
-### Options
-
-```
-      --architecture string            target architecture for the built driver, one of [amd64,arm64] (default "amd64")
-      --as string                      username to impersonate for the operation, user could be a regular user or a service account in a namespace
-      --as-group stringArray           group to impersonate for the operation, this flag can be repeated to specify multiple groups
-      --as-uid string                  uID to impersonate for the operation
-      --builderimage string            docker image to be used to build the kernel module and eBPF probe. If not provided, an automatically selected image will be used.
-      --cache-dir string               default cache directory (default "$HOME/.kube/cache")
-      --certificate-authority string   path to a cert file for the certificate authority
-      --client-certificate string      path to a client certificate file for TLS
-      --client-key string              path to a client key file for TLS
-      --cluster string                 the name of the kubeconfig cluster to use
-  -c, --config string                  config file path (default $HOME/.driverkit.yaml if exists)
-      --context string                 the name of the kubeconfig context to use
-      --driverversion string           driver version as a git commit hash or as a git tag (default "master")
-      --dryrun                         do not actually perform the action
-      --gccversion float          enforce a specific gcc version for the build
-  -h, --help                           help for kubernetes
-      --image-pull-secret string       ImagePullSecret
-      --insecure-skip-tls-verify       if true, the server's certificate will not be checked for validity, this will make your HTTPS connections insecure
-      --kernelconfigdata string        base64 encoded kernel config data: in some systems it can be found under the /boot directory, in other it is gzip compressed under /proc
-      --kernelrelease string           kernel release to build the module for, it can be found by executing 'uname -v'
-      --kernelurls strings             list of kernel header urls (e.g. --kernelurls <URL1> --kernelurls <URL2> --kernelurls "<URL3>,<URL4>")
-      --kernelversion string           kernel version to build the module for, it's the numeric value after the hash when you execute 'uname -v' (default "1")
-      --kubeconfig string              path to the kubeconfig file to use for CLI requests
-  -l, --loglevel string                log level (default "info")
-      --moduledevicename string        kernel module device name (the default is falco, so the device will be under /dev/falco*) (default "falco")
-      --moduledrivername string        kernel module driver name, i.e. the name you see when you check installed modules via lsmod (default "falco")
-  -n, --namespace string               If present, the namespace scope for the pods and its config  (default "default")
-      --output-module string           filepath where to save the resulting kernel module
-      --output-probe string            filepath where to save the resulting eBPF probe
-      --proxy string                   the proxy to use to download data
-      --request-timeout string         the length of time to wait before giving up on a single server request, non-zero values should contain a corresponding time unit (e.g, 1s, 2m, 3h), a value of zero means don't timeout requests (default "0")
-      --run-as-user int                Pods runner user
-  -s, --server string                  the address and port of the Kubernetes API server
-  -t, --target string                  the system to target the build for, one of [amazonlinux,amazonlinux2,amazonlinux2022,archlinux,centos,debian,flatcar,minikube,photon,redhat,rocky,ubuntu,ubuntu-aws,ubuntu-generic,vanilla]
-      --timeout int                    timeout in seconds (default 120)
-      --tls-server-name string         server name to use for server certificate validation, if it is not provided, the hostname used to contact the server is used
-      --token string                   bearer token for authentication to the API server
-      --user string                    the name of the kubeconfig user to use
-```
-
 ### SEE ALSO
 
 * [driverkit](driverkit.md)	 - A command line tool to build Falco kernel modules and eBPF probes.

--- a/docs/driverkit_kubernetes.md
+++ b/docs/driverkit_kubernetes.md
@@ -13,7 +13,7 @@ driverkit kubernetes [flags]
       --as string                      username to impersonate for the operation, user could be a regular user or a service account in a namespace
       --as-group stringArray           group to impersonate for the operation, this flag can be repeated to specify multiple groups
       --as-uid string                  uID to impersonate for the operation
-      --builderimage string            docker image to be used to build the kernel module and eBPF probe. If not provided, the default image will be used. (default "falcosecurity/driverkit-builder:latest")
+      --builderimage string            docker image to be used to build the kernel module and eBPF probe. If not provided, an automatically selected image will be used.
       --cache-dir string               default cache directory (default "$HOME/.kube/cache")
       --certificate-authority string   path to a cert file for the certificate authority
       --client-certificate string      path to a client certificate file for TLS

--- a/pkg/driverbuilder/builder/README.md
+++ b/pkg/driverbuilder/builder/README.md
@@ -124,23 +124,48 @@ Indeed, the hardest part is fetching the kernel headers urls for each distro.
 
 ### 3. Customize GCC version
 
-Driverkit builder image supports 4 gcc versions:
-* GCC-8
-* GCC-6.3.0
-* GCC-5.5.0
-* GCC-4.8.4
+Driverkit builder images support multiple gcc versions:
 
-You can dynamically choose the one you prefer, likely switching on the kernel version.  
-For an example, you can check out Ubuntu builder, namely: `ubuntuGCCVersionFromKernelRelease`.
+From **driverkit-builder_buster** image:
 
-### 4. Customize llvm version
+* /usr/bin/gcc-8
+* /usr/bin/gcc-6 (6.3.0)
+* /usr/bin/gcc-5 (5.5.0)
+* /usr/bin/gcc-4.8 (4.8.4)
 
-Driverkit builder image supports 2 llvm versions:
-* llvm-7
-* llvm-12
+From **driverkit-builder_bullseye** image:
 
-You can dynamically choose the one you prefer, likely switching on the kernel version.  
-For an example, you can check out Debian builder, namely: `debianLLVMVersionFromKernelRelease`.
+* /usr/bin/gcc-9
+* /usr/bin/gcc-10
+
+From **driverkit-builder_bookworm** image:
+
+* /usr/bin/gcc-11
+* /usr/bin/gcc-12
+
+You can dynamically choose the one you prefer, likely switching on the kernel version,
+by letting your builder implement the `builder.GCCVersionRequestor` interface.  
+A sane default is provided, switching on the kernel version.  
+Please note that requested gcc version is used to find the correct builder image to be used.  
+
+Moreover, Driverkit builder images support multiple clang versions:
+
+From **driverkit-builder_buster** image:
+
+* /usr/bin/clang (clang-7)
+
+From **driverkit-builder_bullseye** image:
+
+* /usr/bin/clang (clang-11)
+
+From **driverkit-builder_bookworm** image:
+
+* /usr/bin/clang (clang-14)
+
+Note, however, that there is no mechanism to dynamically choose a clang version,  
+as changing it should not be needed.
+The build will use the one provided by the chosen builder image.  
+Any failure must be treated as a bug, and an issue opened on [libs](https://github.com/falcosecurity/libs) repository.
 
 ### 5. kernel-crawler
 

--- a/pkg/driverbuilder/builder/README.md
+++ b/pkg/driverbuilder/builder/README.md
@@ -18,6 +18,7 @@ Following this simple set of instructions should help you while you implement a 
 
 
 ### 1. Builder file
+
 Create a file, named with the name of the distro you want to add in the `pkg/driverbuilder/builder` folder.
 
 ```bash
@@ -28,16 +29,15 @@ touch pkg/driverbuilder/builder/archlinux.go
 
 Your builder will need a constant for the target it implements. Usually that constant
 can just be the name of the distribution you are implementing. A builder can implement
-more than one target at time. For example, the Ubuntu builder implements both `ubuntu-generic` and `ubuntu-aws`
-to reflect the organization that the distro itself has.
+more than one target at time. For example, the minikube builder is just a vanilla one.
 
 Once you have the constant, you will need to add it to the `BuilderByTarget` map.
-
 
 Open your file and you will need to have something like this:
 
 ```go
 // TargetTypeArchLinux identifies the Arch Linux target.
+/// NOTE: the target name should exactly match the /etc/os-release ID value.
 const TargetTypeArchLinux Type = "archlinux"
 
 type archLinux struct {
@@ -85,7 +85,6 @@ func (c archlinux) TemplateData(cfg Config, kr kernelrelease.KernelRelease, urls
     return archlinuxTemplateData{
         commonTemplateData: cfg.toTemplateData(),
         KernelDownloadURL:  urls[0],
-        GCCVersion:         archlinuxGccVersionFromKernelRelease(kr),
     }
 }
 ```

--- a/pkg/driverbuilder/builder/README.md
+++ b/pkg/driverbuilder/builder/README.md
@@ -38,7 +38,7 @@ Open your file and you will need to have something like this:
 ```go
 // TargetTypeArchLinux identifies the Arch Linux target.
 /// NOTE: the target name should exactly match the /etc/os-release ID value.
-const TargetTypeArchLinux Type = "archlinux"
+const TargetTypeArchLinux Type = "arch"
 
 type archLinux struct {
 }
@@ -142,9 +142,9 @@ From **driverkit-builder_bookworm** image:
 * /usr/bin/gcc-11
 * /usr/bin/gcc-12
 
-You can dynamically choose the one you prefer, likely switching on the kernel version,
+You can dynamically choose the one you prefer,
 by letting your builder implement the `builder.GCCVersionRequestor` interface.  
-A sane default is provided, switching on the kernel version.  
+A sane default is provided, selecting it switching on the kernel version.  
 Please note that requested gcc version is used to find the correct builder image to be used.  
 
 Moreover, Driverkit builder images support multiple clang versions:
@@ -164,7 +164,7 @@ From **driverkit-builder_bookworm** image:
 Note, however, that there is no mechanism to dynamically choose a clang version,  
 as changing it should not be needed.
 The build will use the one provided by the chosen builder image.  
-Any failure must be treated as a bug, and an issue opened on [libs](https://github.com/falcosecurity/libs) repository.
+Any failure must be treated as a bug, therefore and issue must be opened on [libs](https://github.com/falcosecurity/libs) repository.
 
 ### 5. kernel-crawler
 

--- a/pkg/driverbuilder/builder/amazonlinux.go
+++ b/pkg/driverbuilder/builder/amazonlinux.go
@@ -60,7 +60,6 @@ func init() {
 type amazonlinuxTemplateData struct {
 	commonTemplateData
 	KernelDownloadURLs []string
-	LLVMVersion        string
 }
 
 func (a amazonlinux) Name() string {
@@ -79,7 +78,6 @@ func (a amazonlinux) TemplateData(c Config, kr kernelrelease.KernelRelease, urls
 	return amazonlinuxTemplateData{
 		commonTemplateData: c.toTemplateData(),
 		KernelDownloadURLs: urls,
-		LLVMVersion:        amazonLLVMVersionFromKernelRelease(kr),
 	}
 }
 
@@ -313,15 +311,4 @@ func bunzip(data io.Reader) (res []byte, err error) {
 	res = b.Bytes()
 
 	return
-}
-
-func amazonLLVMVersionFromKernelRelease(kr kernelrelease.KernelRelease) string {
-	switch kr.Version {
-	case 4:
-		return "7"
-	case 5:
-		return "12"
-	default:
-		return "12"
-	}
 }

--- a/pkg/driverbuilder/builder/archlinux.go
+++ b/pkg/driverbuilder/builder/archlinux.go
@@ -23,7 +23,6 @@ type archlinux struct {
 type archlinuxTemplateData struct {
 	commonTemplateData
 	KernelDownloadURL string
-	GCCVersion        string
 }
 
 func (c archlinux) Name() string {
@@ -56,20 +55,9 @@ func (c archlinux) URLs(cfg Config, kr kernelrelease.KernelRelease) ([]string, e
 	return urls, nil
 }
 
-func (c archlinux) TemplateData(cfg Config, kr kernelrelease.KernelRelease, urls []string) interface{} {
+func (c archlinux) TemplateData(cfg Config, _ kernelrelease.KernelRelease, urls []string) interface{} {
 	return archlinuxTemplateData{
 		commonTemplateData: cfg.toTemplateData(),
 		KernelDownloadURL:  urls[0],
-		GCCVersion:         archlinuxGccVersionFromKernelRelease(kr),
 	}
-}
-
-func archlinuxGccVersionFromKernelRelease(kr kernelrelease.KernelRelease) string {
-	switch kr.Version {
-	case 3:
-		return "5"
-	case 2:
-		return "4.8"
-	}
-	return "8"
 }

--- a/pkg/driverbuilder/builder/archlinux.go
+++ b/pkg/driverbuilder/builder/archlinux.go
@@ -38,10 +38,14 @@ func (c archlinux) URLs(cfg Config, kr kernelrelease.KernelRelease) ([]string, e
 
 	if kr.Architecture == "amd64" {
 		urls = append(urls, fmt.Sprintf(
-			"https://archive.archlinux.org/packages/l/linux-headers/linux-headers-%s.%s-%s-%s.pkg.tar.xz",
+			"https://archive.archlinux.org/packages/l/linux-headers/linux-headers-%s.%s-%s.pkg.tar.xz",
 			kr.Fullversion,
 			kr.Extraversion,
-			cfg.KernelVersion,
+			kr.Architecture.ToNonDeb()))
+		urls = append(urls, fmt.Sprintf(
+			"https://archive.archlinux.org/packages/l/linux-headers/linux-headers-%s.%s-%s.pkg.tar.zst",
+			kr.Fullversion,
+			kr.Extraversion,
 			kr.Architecture.ToNonDeb()))
 	} else {
 		urls = append(urls, fmt.Sprintf(

--- a/pkg/driverbuilder/builder/archlinux.go
+++ b/pkg/driverbuilder/builder/archlinux.go
@@ -10,7 +10,7 @@ import (
 var archlinuxTemplate string
 
 // TargetTypeArchlinux identifies the Archlinux target.
-const TargetTypeArchlinux Type = "archlinux"
+const TargetTypeArchlinux Type = "arch"
 
 func init() {
 	BuilderByTarget[TargetTypeArchlinux] = &archlinux{}

--- a/pkg/driverbuilder/builder/build.go
+++ b/pkg/driverbuilder/builder/build.go
@@ -16,6 +16,7 @@ type Build struct {
 	ModuleDeviceName   string
 	CustomBuilderImage string
 	KernelUrls         []string
+	GCCVersion         float64
 }
 
 func (b *Build) KernelReleaseFromBuildConfig() kernelrelease.KernelRelease {

--- a/pkg/driverbuilder/builder/builders.go
+++ b/pkg/driverbuilder/builder/builders.go
@@ -123,7 +123,7 @@ type Image struct {
 
 var images = map[string]Image{
 	"buster": {
-		GCCVersion: []float64{4.8, 5, 6, 8},
+		GCCVersion: []float64{4.8, 4.9, 5, 6, 8},
 	},
 	"bullseye": {
 		GCCVersion: []float64{9, 10},
@@ -143,7 +143,10 @@ func defaultGCC(kr kernelrelease.KernelRelease) float64 {
 	case 4:
 		return 8
 	case 3:
-		return 5
+		if kr.PatchLevel >= 18 {
+			return 5
+		}
+		return 4.9
 	case 2:
 		return 4.8
 	default:

--- a/pkg/driverbuilder/builder/builders.go
+++ b/pkg/driverbuilder/builder/builders.go
@@ -210,7 +210,7 @@ func (b *Build) GetBuilderImage() string {
 	for name, img := range images {
 		for _, gcc := range img.GCCVersion {
 			if gcc == b.GCCVersion {
-				return names[0] + "_" + name + ":" + names[1] + "_x86_64" // TODO remove "_x86_64"
+				return names[0] + "_" + name + ":" + names[1]
 			}
 		}
 	}

--- a/pkg/driverbuilder/builder/builders.go
+++ b/pkg/driverbuilder/builder/builders.go
@@ -123,7 +123,7 @@ type Image struct {
 
 var images = map[string]Image{
 	"buster": {
-		GCCVersion: []float64{4.8, 5.5, 6.3, 8},
+		GCCVersion: []float64{4.8, 5, 6, 8},
 	},
 	"bullseye": {
 		GCCVersion: []float64{9, 10},
@@ -143,7 +143,7 @@ func defaultGCC(kr kernelrelease.KernelRelease) float64 {
 	case 4:
 		return 8
 	case 3:
-		return 5.5
+		return 5
 	case 2:
 		return 4.8
 	default:
@@ -152,6 +152,11 @@ func defaultGCC(kr kernelrelease.KernelRelease) float64 {
 }
 
 func (b *Build) SetGCCVersion(builder Builder, kr kernelrelease.KernelRelease) {
+	if b.GCCVersion != 0 {
+		// If set from user, go on
+		return
+	}
+
 	b.GCCVersion = 8 // default value
 
 	distance := math.MaxFloat64

--- a/pkg/driverbuilder/builder/builders_test.go
+++ b/pkg/driverbuilder/builder/builders_test.go
@@ -43,7 +43,7 @@ var gccTests = []struct {
 			FullExtraversion: "-100",
 			Architecture:     "amd64",
 		},
-		expectedGCC: 5,
+		expectedGCC: 4.9,
 	},
 	{
 		config: kernelrelease.KernelRelease{

--- a/pkg/driverbuilder/builder/builders_test.go
+++ b/pkg/driverbuilder/builder/builders_test.go
@@ -1,0 +1,74 @@
+package builder
+
+import (
+	"github.com/falcosecurity/driverkit/pkg/kernelrelease"
+	"testing"
+)
+
+var gccTests = []struct {
+	config      kernelrelease.KernelRelease
+	expectedGCC float64
+}{
+	{
+		config: kernelrelease.KernelRelease{
+			Fullversion:      "4.15.0",
+			Version:          4,
+			PatchLevel:       15,
+			Sublevel:         0,
+			Extraversion:     "188",
+			FullExtraversion: "-188",
+			Architecture:     "amd64",
+		},
+		expectedGCC: 8,
+	},
+	{
+		config: kernelrelease.KernelRelease{
+			Fullversion:      "5.15.0",
+			Version:          5,
+			PatchLevel:       15,
+			Sublevel:         0,
+			Extraversion:     "1004-intel-iotg",
+			FullExtraversion: "-1004-intel-iotg",
+			Architecture:     "amd64",
+		},
+		expectedGCC: 11,
+	},
+	{
+		config: kernelrelease.KernelRelease{
+			Fullversion:      "3.13.0",
+			Version:          3,
+			PatchLevel:       13,
+			Sublevel:         0,
+			Extraversion:     "100",
+			FullExtraversion: "-100",
+			Architecture:     "amd64",
+		},
+		expectedGCC: 5,
+	},
+	{
+		config: kernelrelease.KernelRelease{
+			Fullversion:      "5.18.0",
+			Version:          5,
+			PatchLevel:       18,
+			Sublevel:         0,
+			Extraversion:     "1001-kvm",
+			FullExtraversion: "-1001-kvm",
+			Architecture:     "amd64",
+		},
+		expectedGCC: 12,
+	},
+}
+
+func TestDefaultGCC(t *testing.T) {
+	for _, test := range gccTests {
+		// call function
+		selectedGCC := defaultGCC(test.config)
+
+		// compare errors
+		// there are no official errors, so comparing fmt.Errorf() doesn't really work
+		// compare error message text instead
+		if test.expectedGCC != selectedGCC {
+			t.Fatalf("SelectedGCC (%f) != expectedGCC (%f) with kernelrelease: '%v'", selectedGCC, test.expectedGCC, test.config)
+		}
+	}
+}

--- a/pkg/driverbuilder/builder/centos.go
+++ b/pkg/driverbuilder/builder/centos.go
@@ -23,7 +23,6 @@ type centos struct {
 type centosTemplateData struct {
 	commonTemplateData
 	KernelDownloadURL string
-	GCCVersion        string
 }
 
 func (c centos) Name() string {
@@ -161,20 +160,9 @@ func (c centos) URLs(_ Config, kr kernelrelease.KernelRelease) ([]string, error)
 	return urls, nil
 }
 
-func (c centos) TemplateData(cfg Config, kr kernelrelease.KernelRelease, urls []string) interface{} {
+func (c centos) TemplateData(cfg Config, _ kernelrelease.KernelRelease, urls []string) interface{} {
 	return centosTemplateData{
 		commonTemplateData: cfg.toTemplateData(),
 		KernelDownloadURL:  urls[0],
-		GCCVersion:         centosGccVersionFromKernelRelease(kr),
 	}
-}
-
-func centosGccVersionFromKernelRelease(kr kernelrelease.KernelRelease) string {
-	switch kr.Version {
-	case 3:
-		return "5"
-	case 2:
-		return "4.8"
-	}
-	return "8"
 }

--- a/pkg/driverbuilder/builder/debian.go
+++ b/pkg/driverbuilder/builder/debian.go
@@ -30,7 +30,6 @@ type debianTemplateData struct {
 	commonTemplateData
 	KernelDownloadURLS []string
 	KernelLocalVersion string
-	LLVMVersion        string
 	KernelArch         string
 }
 
@@ -55,7 +54,6 @@ func (v debian) TemplateData(c Config, kr kernelrelease.KernelRelease, urls []st
 		commonTemplateData: c.toTemplateData(),
 		KernelDownloadURLS: urls,
 		KernelLocalVersion: kr.FullExtraversion,
-		LLVMVersion:        debianLLVMVersionFromKernelRelease(kr),
 		KernelArch:         kr.Architecture.String(),
 	}
 }
@@ -187,12 +185,4 @@ func debianKbuildURLFromRelease(kr kernelrelease.KernelRelease) (string, error) 
 	}
 
 	return fmt.Sprintf("%s%s", baseURL, match[1]), nil
-}
-
-func debianLLVMVersionFromKernelRelease(kr kernelrelease.KernelRelease) string {
-	switch kr.Version {
-	case 5:
-		return "12"
-	}
-	return "7"
 }

--- a/pkg/driverbuilder/builder/photon.go
+++ b/pkg/driverbuilder/builder/photon.go
@@ -23,7 +23,6 @@ type photon struct {
 type photonTemplateData struct {
 	commonTemplateData
 	KernelDownloadURL string
-	GCCVersion        string
 }
 
 func (p photon) Name() string {
@@ -42,7 +41,6 @@ func (p photon) TemplateData(cfg Config, kr kernelrelease.KernelRelease, urls []
 	return photonTemplateData{
 		commonTemplateData: cfg.toTemplateData(),
 		KernelDownloadURL:  urls[0],
-		GCCVersion:         photonGccVersionFromKernelRelease(kr),
 	}
 }
 
@@ -89,11 +87,4 @@ func fetchPhotonKernelURLS(kr kernelrelease.KernelRelease) []string {
 		}
 	}
 	return urls
-}
-
-func photonGccVersionFromKernelRelease(kr kernelrelease.KernelRelease) string {
-	switch kr.Version {
-	default:
-		return "8"
-	}
 }

--- a/pkg/driverbuilder/builder/rocky.go
+++ b/pkg/driverbuilder/builder/rocky.go
@@ -19,7 +19,6 @@ func init() {
 type rockyTemplateData struct {
 	commonTemplateData
 	KernelDownloadURL string
-	GCCVersion        string
 }
 
 // rocky is a driverkit target.
@@ -42,7 +41,6 @@ func (c rocky) TemplateData(cfg Config, kr kernelrelease.KernelRelease, urls []s
 	return rockyTemplateData{
 		commonTemplateData: cfg.toTemplateData(),
 		KernelDownloadURL:  urls[0],
-		GCCVersion:         rockyGccVersionFromKernelRelease(kr),
 	}
 }
 
@@ -63,14 +61,4 @@ func fetchRockyKernelURLS(kr kernelrelease.KernelRelease) []string {
 		))
 	}
 	return urls
-}
-
-func rockyGccVersionFromKernelRelease(kr kernelrelease.KernelRelease) string {
-	switch kr.Version {
-	case 3:
-		return "5"
-	case 2:
-		return "4.8"
-	}
-	return "8"
 }

--- a/pkg/driverbuilder/builder/templates/amazonlinux.sh
+++ b/pkg/driverbuilder/builder/templates/amazonlinux.sh
@@ -28,7 +28,7 @@ mv usr/src/kernels/*/* /tmp/kernel
 # Build the kernel module
 cd {{ .DriverBuildDir }}
 
-make KERNELDIR=/tmp/kernel CC=/usr/bin/gcc LD=/usr/bin/ld.bfd CROSS_COMPILE=""
+make KERNELDIR=/tmp/kernel CC=/usr/bin/gcc-{{ .GCCVersion }} LD=/usr/bin/ld.bfd CROSS_COMPILE=""
 mv {{ .ModuleDriverName }}.ko {{ .ModuleFullPath }}
 # Print results
 modinfo {{ .ModuleFullPath }}
@@ -37,6 +37,6 @@ modinfo {{ .ModuleFullPath }}
 {{ if .BuildProbe }}
 # Build the eBPF probe
 cd {{ .DriverBuildDir }}/bpf
-make LLC=/usr/bin/llc-{{ .LLVMVersion }} CLANG=/usr/bin/clang-{{ .LLVMVersion }} KERNELDIR=/tmp/kernel
+make KERNELDIR=/tmp/kernel
 ls -l probe.o
 {{ end }}

--- a/pkg/driverbuilder/builder/templates/archlinux.sh
+++ b/pkg/driverbuilder/builder/templates/archlinux.sh
@@ -34,6 +34,6 @@ modinfo {{ .ModuleFullPath }}
 {{ if .BuildProbe }}
 # Build the eBPF probe
 cd {{ .DriverBuildDir }}/bpf
-make LLC=/usr/bin/llc-7 CLANG=/usr/bin/clang-7 KERNELDIR=/tmp/kernel
+make KERNELDIR=/tmp/kernel
 ls -l probe.o
 {{ end }}

--- a/pkg/driverbuilder/builder/templates/centos.sh
+++ b/pkg/driverbuilder/builder/templates/centos.sh
@@ -34,6 +34,6 @@ modinfo {{ .ModuleFullPath }}
 {{ if .BuildProbe }}
 # Build the eBPF probe
 cd {{ .DriverBuildDir }}/bpf
-make LLC=/usr/bin/llc-7 CLANG=/usr/bin/clang-7 KERNELDIR=/tmp/kernel
+make KERNELDIR=/tmp/kernel
 ls -l probe.o
 {{ end }}

--- a/pkg/driverbuilder/builder/templates/debian.sh
+++ b/pkg/driverbuilder/builder/templates/debian.sh
@@ -32,7 +32,7 @@ sourcedir=$(find . -type d -name "linux-headers-*{{ .KernelArch }}" | head -n 1 
 {{ if .BuildModule }}
 # Build the module
 cd {{ .DriverBuildDir }}
-make CC=/usr/bin/gcc-8 KERNELDIR=$sourcedir
+make CC=/usr/bin/gcc-{{ .GCCVersion }} KERNELDIR=$sourcedir
 mv {{ .ModuleDriverName }}.ko {{ .ModuleFullPath }}
 strip -g {{ .ModuleFullPath }}
 # Print results
@@ -42,6 +42,6 @@ modinfo {{ .ModuleFullPath }}
 {{ if .BuildProbe }}
 # Build the eBPF probe
 cd {{ .DriverBuildDir }}/bpf
-make LLC=/usr/bin/llc-{{ .LLVMVersion }} CLANG=/usr/bin/clang-{{ .LLVMVersion }} KERNELDIR=$sourcedir
+make KERNELDIR=$sourcedir
 ls -l probe.o
 {{ end }}

--- a/pkg/driverbuilder/builder/templates/flatcar.sh
+++ b/pkg/driverbuilder/builder/templates/flatcar.sh
@@ -40,6 +40,6 @@ modinfo {{ .ModuleFullPath }}
 {{ if .BuildProbe }}
 # Build the eBPF probe
 cd {{ .DriverBuildDir }}/bpf
-make LLC=/usr/bin/llc-12 CLANG=/usr/bin/clang-12 KERNELDIR=/tmp/kernel
+make KERNELDIR=/tmp/kernel
 ls -l probe.o
 {{ end }}

--- a/pkg/driverbuilder/builder/templates/photonos.sh
+++ b/pkg/driverbuilder/builder/templates/photonos.sh
@@ -36,6 +36,6 @@ modinfo {{ .ModuleFullPath }}
 
 # Build the eBPF probe
 cd {{ .DriverBuildDir }}/bpf
-make LLC=/usr/bin/llc-7 CLANG=/usr/bin/clang-7 KERNELDIR=/tmp/kernel
+make KERNELDIR=/tmp/kernel
 ls -l probe.o
 {{ end }}

--- a/pkg/driverbuilder/builder/templates/redhat.sh
+++ b/pkg/driverbuilder/builder/templates/redhat.sh
@@ -26,7 +26,7 @@ mv usr/src/kernels/*/* /tmp/kernel
 {{ if .BuildModule }}
 # Build the module
 cd {{ .DriverBuildDir }}
-make KERNELDIR=/tmp/kernel
+make CC=/usr/bin/gcc-{{ .GCCVersion }} KERNELDIR=/tmp/kernel
 mv {{ .ModuleDriverName }}.ko {{ .ModuleFullPath }}
 strip -g {{ .ModuleFullPath }}
 # Print results
@@ -36,6 +36,6 @@ modinfo {{ .ModuleFullPath }}
 {{ if .BuildProbe }}
 # Build the eBPF probe
 cd {{ .DriverBuildDir }}/bpf
-make LLC=/usr/bin/llc CLANG=/usr/bin/clang KERNELDIR=/tmp/kernel
+make KERNELDIR=/tmp/kernel
 ls -l probe.o
 {{ end }}

--- a/pkg/driverbuilder/builder/templates/rocky.sh
+++ b/pkg/driverbuilder/builder/templates/rocky.sh
@@ -34,6 +34,6 @@ modinfo {{ .ModuleFullPath }}
 {{ if .BuildProbe }}
 # Build the eBPF probe
 cd {{ .DriverBuildDir }}/bpf
-make LLC=/usr/bin/llc-7 CLANG=/usr/bin/clang-7 KERNELDIR=/tmp/kernel
+make KERNELDIR=/tmp/kernel
 ls -l probe.o
 {{ end }}

--- a/pkg/driverbuilder/builder/templates/ubuntu.sh
+++ b/pkg/driverbuilder/builder/templates/ubuntu.sh
@@ -37,18 +37,6 @@ modinfo {{ .ModuleFullPath }}
 {{ if .BuildProbe }}
 # Build the eBPF probe
 cd {{ .DriverBuildDir }}/bpf
-if [[ -x /usr/bin/llc ]]; then
-	LLC_BIN=/usr/bin/llc
-else
-	LLC_BIN=/usr/bin/llc-7
-fi
-
-if [[ -x /usr/bin/clang ]]; then
-	CLANG_BIN=/usr/bin/clang
-else
-	CLANG_BIN=/usr/bin/clang-7
-fi
-
-make LLC=$LLC_BIN CLANG=$CLANG_BIN KERNELDIR=$sourcedir
+make KERNELDIR=$sourcedir
 ls -l probe.o
 {{ end }}

--- a/pkg/driverbuilder/builder/templates/vanilla.sh
+++ b/pkg/driverbuilder/builder/templates/vanilla.sh
@@ -35,7 +35,7 @@ make KCONFIG_CONFIG=/tmp/kernel.config modules_prepare
 {{ if .BuildModule }}
 # Build the kernel module
 cd {{ .DriverBuildDir }}
-make KERNELDIR=/tmp/kernel
+make CC=/usr/bin/gcc-{{ .GCCVersion }} KERNELDIR=/tmp/kernel
 mv {{ .ModuleDriverName }}.ko {{ .ModuleFullPath }}
 strip -g {{ .ModuleFullPath }}
 # Print results
@@ -45,6 +45,6 @@ modinfo {{ .ModuleFullPath }}
 {{ if .BuildProbe }}
 # Build the eBPF probe
 cd {{ .DriverBuildDir }}/bpf
-make LLC=/usr/bin/llc-7 CLANG=/usr/bin/clang-7 KERNELDIR=/tmp/kernel
+make KERNELDIR=/tmp/kernel
 ls -l probe.o
 {{ end }}

--- a/pkg/driverbuilder/builder/ubuntu.go
+++ b/pkg/driverbuilder/builder/ubuntu.go
@@ -81,9 +81,9 @@ func (v ubuntu) GCCVersion(kr kernelrelease.KernelRelease) float64 {
 	case 5:
 		switch {
 		case kr.PatchLevel >= 18:
-			return 11
+			return 12
 		case kr.PatchLevel >= 11:
-			return 10
+			return 11
 		}
 	}
 	return 8

--- a/pkg/driverbuilder/builder/ubuntu.go
+++ b/pkg/driverbuilder/builder/ubuntu.go
@@ -23,7 +23,6 @@ type ubuntuTemplateData struct {
 	KernelDownloadURLS   []string
 	KernelLocalVersion   string
 	KernelHeadersPattern string
-	GCCVersion           string
 }
 
 func init() {
@@ -67,8 +66,27 @@ func (v ubuntu) TemplateData(c Config, kr kernelrelease.KernelRelease, urls []st
 		KernelDownloadURLS:   urls,
 		KernelLocalVersion:   kr.FullExtraversion,
 		KernelHeadersPattern: headersPattern,
-		GCCVersion:           ubuntuGCCVersionFromKernelRelease(kr),
 	}
+}
+
+func (v ubuntu) GCCVersion(kr kernelrelease.KernelRelease) float64 {
+	switch kr.Version {
+	case 3:
+		switch {
+		case kr.PatchLevel == 13 || kr.PatchLevel == 2:
+			return 4.8
+		default:
+			return 6
+		}
+	case 5:
+		switch {
+		case kr.PatchLevel >= 18:
+			return 11
+		case kr.PatchLevel >= 11:
+			return 10
+		}
+	}
+	return 8
 }
 
 func ubuntuHeadersURLFromRelease(kr kernelrelease.KernelRelease, kv string) ([]string, error) {
@@ -244,24 +262,4 @@ func parseUbuntuExtraVersion(extraversion string) (string, string) {
 
 	// if unable to parse a flavor assume "generic" and return back the extraversion passed in
 	return extraversion, "generic"
-}
-
-func ubuntuGCCVersionFromKernelRelease(kr kernelrelease.KernelRelease) string {
-	switch kr.Version {
-	case 3:
-		switch {
-		case kr.PatchLevel == 13 || kr.PatchLevel == 2:
-			return "4.8"
-		default:
-			return "6"
-		}
-	case 5:
-		switch {
-		case kr.PatchLevel >= 18:
-			return "11"
-		case kr.PatchLevel >= 11:
-			return "10"
-		}
-	}
-	return "8"
 }

--- a/pkg/driverbuilder/builder/ubuntu_test.go
+++ b/pkg/driverbuilder/builder/ubuntu_test.go
@@ -13,7 +13,7 @@ var tests = []struct {
 	expected      struct {
 		headersURLs []string
 		urls        []string
-		gccVersion  string
+		gccVersion  float64
 		firstExtra  string
 		flavor      string
 		err         error
@@ -33,14 +33,14 @@ var tests = []struct {
 		expected: struct {
 			headersURLs []string
 			urls        []string
-			gccVersion  string
+			gccVersion  float64
 			firstExtra  string
 			flavor      string
 			err         error
 		}{
 			headersURLs: []string{"https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-4.15.0-188-generic_4.15.0-188.199_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-4.15.0-188_4.15.0-188.199_all.deb"},
 			urls:        []string{"https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-4.15.0-188_4.15.0-188.199_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-4.15.0-188-generic_4.15.0-188.199_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-generic-headers-4.15.0-188_4.15.0-188.199_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-4.15.0-188_4.15.0-188.199_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-4.15.0-188_4.15.0-188.199_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-generic/linux-headers-4.15.0-188_4.15.0-188.199_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-generic/linux-headers-4.15.0-188-generic_4.15.0-188.199_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-generic/linux-generic-headers-4.15.0-188_4.15.0-188.199_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-generic/linux-headers-4.15.0-188_4.15.0-188.199_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-generic/linux-headers-4.15.0-188_4.15.0-188.199_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-generic-4.15/linux-headers-4.15.0-188_4.15.0-188.199_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-generic-4.15/linux-headers-4.15.0-188-generic_4.15.0-188.199_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-generic-4.15/linux-generic-headers-4.15.0-188_4.15.0-188.199_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-generic-4.15/linux-headers-4.15.0-188_4.15.0-188.199_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-generic-4.15/linux-headers-4.15.0-188_4.15.0-188.199_all.deb"},
-			gccVersion:  "8",
+			gccVersion:  8,
 			firstExtra:  "188",
 			flavor:      "generic",
 			err:         fmt.Errorf("kernel headers not found"),
@@ -60,14 +60,14 @@ var tests = []struct {
 		expected: struct {
 			headersURLs []string
 			urls        []string
-			gccVersion  string
+			gccVersion  float64
 			firstExtra  string
 			flavor      string
 			err         error
 		}{
 			headersURLs: []string{"http://ports.ubuntu.com/ubuntu-ports/pool/main/l/linux-aws/linux-headers-4.15.0-1140-aws_4.15.0-1140.151_arm64.deb", "http://ports.ubuntu.com/ubuntu-ports/pool/main/l/linux-aws/linux-aws-headers-4.15.0-1140_4.15.0-1140.151_all.deb"},
 			urls:        []string{"http://ports.ubuntu.com/ubuntu-ports/pool/main/l/linux/linux-headers-4.15.0-1140-aws_4.15.0-1140.151_arm64_all.deb", "http://ports.ubuntu.com/ubuntu-ports/pool/main/l/linux/linux-headers-4.15.0-1140-aws_4.15.0-1140.151_arm64.deb", "http://ports.ubuntu.com/ubuntu-ports/pool/main/l/linux/linux-aws-headers-4.15.0-1140_4.15.0-1140.151_all.deb", "http://ports.ubuntu.com/ubuntu-ports/pool/main/l/linux-aws/linux-headers-4.15.0-1140-aws_4.15.0-1140.151_arm64_all.deb", "http://ports.ubuntu.com/ubuntu-ports/pool/main/l/linux-aws/linux-headers-4.15.0-1140-aws_4.15.0-1140.151_arm64.deb", "http://ports.ubuntu.com/ubuntu-ports/pool/main/l/linux-aws/linux-aws-headers-4.15.0-1140_4.15.0-1140.151_all.deb", "http://ports.ubuntu.com/ubuntu-ports/pool/main/l/linux-aws-4.15/linux-headers-4.15.0-1140-aws_4.15.0-1140.151_arm64_all.deb", "http://ports.ubuntu.com/ubuntu-ports/pool/main/l/linux-aws-4.15/linux-headers-4.15.0-1140-aws_4.15.0-1140.151_arm64.deb", "http://ports.ubuntu.com/ubuntu-ports/pool/main/l/linux-aws-4.15/linux-aws-headers-4.15.0-1140_4.15.0-1140.151_all.deb"},
-			gccVersion:  "8",
+			gccVersion:  8,
 			firstExtra:  "1140",
 			flavor:      "aws",
 			err:         nil,
@@ -87,14 +87,14 @@ var tests = []struct {
 		expected: struct {
 			headersURLs []string
 			urls        []string
-			gccVersion  string
+			gccVersion  float64
 			firstExtra  string
 			flavor      string
 			err         error
 		}{
 			headersURLs: []string{"https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-intel-iotg/linux-headers-5.15.0-1004-intel-iotg_5.15.0-1004.6_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-intel-iotg/linux-intel-iotg-headers-5.15.0-1004_5.15.0-1004.6_all.deb"},
 			urls:        []string{"https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-5.15.0-1004-intel-iotg_5.15.0-1004.6_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-5.15.0-1004-intel-iotg_5.15.0-1004.6_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-intel-iotg-headers-5.15.0-1004_5.15.0-1004.6_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-intel-iotg/linux-headers-5.15.0-1004-intel-iotg_5.15.0-1004.6_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-intel-iotg/linux-headers-5.15.0-1004-intel-iotg_5.15.0-1004.6_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-intel-iotg/linux-intel-iotg-headers-5.15.0-1004_5.15.0-1004.6_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-intel-iotg-5.15/linux-headers-5.15.0-1004-intel-iotg_5.15.0-1004.6_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-intel-iotg-5.15/linux-headers-5.15.0-1004-intel-iotg_5.15.0-1004.6_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-intel-iotg-5.15/linux-intel-iotg-headers-5.15.0-1004_5.15.0-1004.6_all.deb"},
-			gccVersion:  "10",
+			gccVersion:  11,
 			firstExtra:  "1004",
 			flavor:      "intel-iotg",
 			err:         nil,
@@ -114,14 +114,14 @@ var tests = []struct {
 		expected: struct {
 			headersURLs []string
 			urls        []string
-			gccVersion  string
+			gccVersion  float64
 			firstExtra  string
 			flavor      string
 			err         error
 		}{
 			headersURLs: []string{},
 			urls:        []string{"https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-5.15.0-24-lowlatency-hwe-5.15_5.15.0-24.24~20.04.3_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-5.15.0-24-lowlatency-hwe_5.15.0-24.24~20.04.3_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-lowlatency-hwe-headers-5.15.0-24_5.15.0-24.24~20.04.3_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-5.15.0-24-lowlatency-hwe-5.15_5.15.0-24.24~20.04.3_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-lowlatency-hwe/linux-headers-5.15.0-24-lowlatency-hwe-5.15_5.15.0-24.24~20.04.3_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-lowlatency-hwe/linux-headers-5.15.0-24-lowlatency-hwe_5.15.0-24.24~20.04.3_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-lowlatency-hwe/linux-lowlatency-hwe-headers-5.15.0-24_5.15.0-24.24~20.04.3_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-lowlatency-hwe/linux-headers-5.15.0-24-lowlatency-hwe-5.15_5.15.0-24.24~20.04.3_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-lowlatency-hwe-5.15/linux-headers-5.15.0-24-lowlatency-hwe-5.15_5.15.0-24.24~20.04.3_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-lowlatency-hwe-5.15/linux-headers-5.15.0-24-lowlatency-hwe_5.15.0-24.24~20.04.3_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-lowlatency-hwe-5.15/linux-lowlatency-hwe-headers-5.15.0-24_5.15.0-24.24~20.04.3_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-lowlatency-hwe-5.15/linux-headers-5.15.0-24-lowlatency-hwe-5.15_5.15.0-24.24~20.04.3_amd64.deb"},
-			gccVersion:  "10",
+			gccVersion:  11,
 			firstExtra:  "24",
 			flavor:      "lowlatency-hwe",
 			err:         fmt.Errorf("kernel headers not found"),
@@ -141,14 +141,14 @@ var tests = []struct {
 		expected: struct {
 			headersURLs []string
 			urls        []string
-			gccVersion  string
+			gccVersion  float64
 			firstExtra  string
 			flavor      string
 			err         error
 		}{
 			headersURLs: []string{"https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-3.13.0-100-generic_3.13.0-100.147_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-3.13.0-100_3.13.0-100.147_all.deb"},
 			urls:        []string{"https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-3.13.0-100_3.13.0-100.147_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-3.13.0-100-generic_3.13.0-100.147_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-generic-headers-3.13.0-100_3.13.0-100.147_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-3.13.0-100_3.13.0-100.147_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-3.13.0-100_3.13.0-100.147_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-generic/linux-headers-3.13.0-100_3.13.0-100.147_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-generic/linux-headers-3.13.0-100-generic_3.13.0-100.147_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-generic/linux-generic-headers-3.13.0-100_3.13.0-100.147_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-generic/linux-headers-3.13.0-100_3.13.0-100.147_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-generic/linux-headers-3.13.0-100_3.13.0-100.147_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-generic-3.13/linux-headers-3.13.0-100_3.13.0-100.147_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-generic-3.13/linux-headers-3.13.0-100-generic_3.13.0-100.147_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-generic-3.13/linux-generic-headers-3.13.0-100_3.13.0-100.147_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-generic-3.13/linux-headers-3.13.0-100_3.13.0-100.147_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-generic-3.13/linux-headers-3.13.0-100_3.13.0-100.147_all.deb"},
-			gccVersion:  "4.8",
+			gccVersion:  4.8,
 			firstExtra:  "100",
 			flavor:      "generic",
 			err:         nil,
@@ -168,14 +168,14 @@ var tests = []struct {
 		expected: struct {
 			headersURLs []string
 			urls        []string
-			gccVersion  string
+			gccVersion  float64
 			firstExtra  string
 			flavor      string
 			err         error
 		}{
 			headersURLs: []string{},
 			urls:        []string{"https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-3.16.0-38-lts-utopic_3.16.0-38.52~14.04.1_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-3.16.0-38-lts-utopic_3.16.0-38.52~14.04.1_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-lts-utopic-headers-3.16.0-38_3.16.0-38.52~14.04.1_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-lts-utopic/linux-headers-3.16.0-38-lts-utopic_3.16.0-38.52~14.04.1_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-lts-utopic/linux-headers-3.16.0-38-lts-utopic_3.16.0-38.52~14.04.1_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-lts-utopic/linux-lts-utopic-headers-3.16.0-38_3.16.0-38.52~14.04.1_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-lts-utopic-3.16/linux-headers-3.16.0-38-lts-utopic_3.16.0-38.52~14.04.1_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-lts-utopic-3.16/linux-headers-3.16.0-38-lts-utopic_3.16.0-38.52~14.04.1_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-lts-utopic-3.16/linux-lts-utopic-headers-3.16.0-38_3.16.0-38.52~14.04.1_all.deb"},
-			gccVersion:  "6",
+			gccVersion:  6,
 			firstExtra:  "38",
 			flavor:      "lts-utopic",
 			err:         nil,
@@ -195,14 +195,14 @@ var tests = []struct {
 		expected: struct {
 			headersURLs []string
 			urls        []string
-			gccVersion  string
+			gccVersion  float64
 			firstExtra  string
 			flavor      string
 			err         error
 		}{
 			headersURLs: []string{"https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-kvm/linux-headers-5.19.0-1004-kvm_5.19.0-1004.4_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-kvm/linux-kvm-headers-5.19.0-1004_5.19.0-1004.4_all.deb"},
 			urls:        []string{"https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-5.19.0-1004-kvm_5.19.0-1004.4_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-5.19.0-1004-kvm_5.19.0-1004.4_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-kvm-headers-5.19.0-1004_5.19.0-1004.4_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-kvm/linux-headers-5.19.0-1004-kvm_5.19.0-1004.4_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-kvm/linux-headers-5.19.0-1004-kvm_5.19.0-1004.4_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-kvm/linux-kvm-headers-5.19.0-1004_5.19.0-1004.4_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-kvm-5.19/linux-headers-5.19.0-1004-kvm_5.19.0-1004.4_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-kvm-5.19/linux-headers-5.19.0-1004-kvm_5.19.0-1004.4_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-kvm-5.19/linux-kvm-headers-5.19.0-1004_5.19.0-1004.4_all.deb"},
-			gccVersion:  "11",
+			gccVersion:  12,
 			firstExtra:  "1004",
 			flavor:      "kvm",
 			err:         nil,
@@ -297,12 +297,13 @@ func TestFetchUbuntuKernelURL(t *testing.T) {
 }
 
 func TestUbuntuGCCVersionFromKernelRelease(t *testing.T) {
+	b := ubuntu{}
 	for _, test := range tests {
 		input := test.config
-		gotGCCVersion := ubuntuGCCVersionFromKernelRelease(input)
+		gotGCCVersion := b.GCCVersion(input)
 		if gotGCCVersion != test.expected.gccVersion {
 			t.Errorf(
-				"Test Input: [ '%v' ] | Got: [ '%s' ] / Want: [ '%s' ]",
+				"Test Input: [ '%v' ] | Got: [ '%f' ] / Want: [ '%f' ]",
 				input,
 				gotGCCVersion,
 				test.expected.gccVersion,

--- a/pkg/driverbuilder/buildprocessor.go
+++ b/pkg/driverbuilder/buildprocessor.go
@@ -4,8 +4,6 @@ import (
 	"github.com/falcosecurity/driverkit/pkg/driverbuilder/builder"
 )
 
-var BuilderBaseImage = "falcosecurity/driverkit-builder:latest" // This is overwritten when using the Makefile to build
-
 type BuildProcessor interface {
 	Start(b *builder.Build) error
 	String() string

--- a/pkg/driverbuilder/docker.go
+++ b/pkg/driverbuilder/docker.go
@@ -110,6 +110,8 @@ func (bp *DockerBuildProcessor) Start(b *builder.Build) error {
 		return err
 	}
 
+	kr := b.KernelReleaseFromBuildConfig()
+
 	// create a builder based on the choosen build type
 	v, err := builder.Factory(b.TargetType)
 	if err != nil {
@@ -123,7 +125,6 @@ func (bp *DockerBuildProcessor) Start(b *builder.Build) error {
 	}
 
 	// Generate the build script from the builder
-	kr := c.Build.KernelReleaseFromBuildConfig()
 	driverkitScript, err := builder.Script(v, c, kr)
 	if err != nil {
 		return err
@@ -148,10 +149,7 @@ func (bp *DockerBuildProcessor) Start(b *builder.Build) error {
 		return err
 	}
 
-	builderImage := BuilderBaseImage
-	if len(b.CustomBuilderImage) > 0 {
-		builderImage = b.CustomBuilderImage
-	}
+	builderImage := b.GetBuilderImage()
 
 	// Create the container
 	ctx := context.Background()

--- a/pkg/driverbuilder/docker.go
+++ b/pkg/driverbuilder/docker.go
@@ -177,6 +177,10 @@ func (bp *DockerBuildProcessor) Start(b *builder.Build) error {
 		}
 	}
 
+	logger.
+		WithField("image", builderImage).
+		Debug("starting container")
+
 	containerCfg := &container.Config{
 		Tty:   true,
 		Cmd:   []string{"/bin/sleep", strconv.Itoa(bp.timeout)},

--- a/pkg/driverbuilder/kubernetes.go
+++ b/pkg/driverbuilder/kubernetes.go
@@ -72,6 +72,8 @@ func (bp *KubernetesBuildProcessor) buildModule(build *builder.Build) error {
 	podClient := bp.coreV1Client.Pods(namespace)
 	configClient := bp.coreV1Client.ConfigMaps(namespace)
 
+	kr := build.KernelReleaseFromBuildConfig()
+
 	// create a builder based on the chosen build type
 	v, err := builder.Factory(build.TargetType)
 	if err != nil {
@@ -86,7 +88,6 @@ func (bp *KubernetesBuildProcessor) buildModule(build *builder.Build) error {
 	}
 
 	// generate the build script from the builder
-	kr := c.Build.KernelReleaseFromBuildConfig()
 	res, err := builder.Script(v, c, kr)
 	if err != nil {
 		return err
@@ -164,10 +165,7 @@ func (bp *KubernetesBuildProcessor) buildModule(build *builder.Build) error {
 		)
 	}
 
-	builderImage := BuilderBaseImage
-	if len(build.CustomBuilderImage) > 0 {
-		builderImage = build.CustomBuilderImage
-	}
+	builderImage := build.GetBuilderImage()
 
 	secuContext := corev1.PodSecurityContext{
 		RunAsUser: &bp.runAsUser,

--- a/pkg/kernelrelease/kernelrelease.go
+++ b/pkg/kernelrelease/kernelrelease.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	kernelVersionPattern = regexp.MustCompile(`(?P<fullversion>^(?P<version>0|[1-9]\d*)\.(?P<patchlevel>0|[1-9]\d*)\.(?P<sublevel>0|[1-9]\d*))(?P<fullextraversion>-(?P<extraversion>0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-_]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$`)
+	kernelVersionPattern = regexp.MustCompile(`(?P<fullversion>^(?P<version>0|[1-9]\d*)\.(?P<patchlevel>0|[1-9]\d*)\.(?P<sublevel>0|[1-9]\d*))(?P<fullextraversion>[-|.](?P<extraversion>0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-_]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$`)
 )
 
 // Architectures is a Map [Architecture] -> non-deb-ArchitectureString

--- a/pkg/kernelrelease/kernelrelease_test.go
+++ b/pkg/kernelrelease/kernelrelease_test.go
@@ -144,6 +144,17 @@ func TestFromString(t *testing.T) {
 				FullExtraversion: "-1044-gke",
 			},
 		},
+		"arch version": {
+			kernelVersionStr: "5.19.3.arch1-1",
+			want: KernelRelease{
+				Fullversion:      "5.19.3",
+				Version:          5,
+				PatchLevel:       19,
+				Sublevel:         3,
+				Extraversion:     "arch1-1",
+				FullExtraversion: ".arch1-1",
+			},
+		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/validate/isimagename.go
+++ b/validate/isimagename.go
@@ -13,6 +13,11 @@ const alphabet = letters + digits + separators
 func isImageName(fl validator.FieldLevel) bool {
 	name := fl.Field().String()
 
+	// default value
+	if name == "" {
+		return true
+	}
+
 	for _, c := range name {
 		if !strings.ContainsRune(alphabet, c) {
 			return false


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

/area cmd

/area pkg

/area docs

> /area tests


**What this PR does / why we need it**:

This PR adds support for multiple builder images.
At the moment, 3 of them are supported:
* the old `buster` one
* a `bullseye` one
* a `bookworm` one

In my tests, they allowed to build basically every 5.X kernel for ubuntu, using config stolen by test-infra, with kernelurls (aside from a bunch of `kernel headers not found` that probably mean that Ubuntu dropped support for these kernels).

More tests can be useful of course :) 

I will try to auto-review the PR to make it easier to follow the code.

Moreover, a new option `gccversion` is now available, to force a gccversion (and therefore a builder image) for a given build.

Note that i completely dropped support for multiple clang versions, removing clang from our support matrix; if an eBPF probe cannot be built with clang shipped in any of the supported builder distros, then it is a bug of libs and an issue should be opened.  
We support clang7+ for our eBPF probe in libs.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #194

**Special notes for your reviewer**:

Most probably the CI will fail because the needed builder images are not present (given that they will be pushed only once the PR is merged :D )
We might want to avoid running integration-tests on this one, to avoid the errors; i don't really know.

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
new: support multiple builder images
```
