### PR TITLE
fix(kubernetes-probe): Fix inconstancy of probe file download + fix removing of the lock

### DIFF
--- a/pkg/driverbuilder/templates.go
+++ b/pkg/driverbuilder/templates.go
@@ -18,11 +18,18 @@ while true; do
 done
 `
 
-// waitForFileAndCat MUST only output the file, any other output will break
+var deleteLock = `
+rm -f /tmp/download.lock
+`
+
+const moduleLockFile = "/tmp/module.lock"
+const probeLockFile = "/tmp/probe.lock"
+
+// waitForLockAndCat MUST only output the file, any other output will break
 // the download file itself because it goes trough stdout
-var waitForFileAndCat = `
+var waitForLockAndCat = `
 while true; do
-  if [ ! -f "$1" ]; then
+  if [ -f "$2" ]; then
 	sleep 10 1>&/dev/null
 	continue
   fi


### PR DESCRIPTION
Signed-off-by: Lyonel Martinez <lyonel.martinez@numberly.com>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area pkg

**What this PR does / why we need it**:

Fix inconstancy in probe module extraction. This bug was due to  a too slow compilation, letting Driverkit trying to get the file while it was still empty. Diverse fixes on lock behavior.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
