### PR TITLE
fix(pkg,cmd,validate): fixed flatcar builder

### DIFF
--- a/Example_configs.md
+++ b/Example_configs.md
@@ -128,7 +128,8 @@ driverversion: master
 ## flatcar
 
 Example configuration file to build both the Kernel module and eBPF probe for Flatcar.
-The Flatcar release version needs to be provided in the `kernelrelease` field instead of the kernel version.
+The Flatcar release version needs to be provided in the `kernelrelease` field instead of the kernel version;
+moreover, kernelconfigdata must be provided.
 
 ```yaml
 kernelrelease: 3185.0.0
@@ -137,6 +138,7 @@ output:
   module: /tmp/falco-flatcar-3185.0.0.ko
   probe: /tmp/falco-flatcar-3185.0.0.o
 driverversion: master
+kernelconfigdata: Q09ORklHX0ZBTk9USUZZPXkKQ09ORklHX0t...
 ```
 
 ## minikube

--- a/cmd/root_options.go
+++ b/cmd/root_options.go
@@ -119,8 +119,12 @@ func (ro *RootOptions) toBuild() *builder.Build {
 func RootOptionsLevelValidation(level validator.StructLevel) {
 	opts := level.Current().Interface().(RootOptions)
 
-	if len(opts.KernelConfigData) == 0 && opts.Target == builder.TargetTypeVanilla.String() {
-		level.ReportError(opts.KernelConfigData, "kernelConfigData", "KernelConfigData", "required_kernelconfigdata_with_target_vanilla", "")
+	if opts.Target == builder.TargetTypeVanilla.String() ||
+		opts.Target == builder.TargetTypeMinikube.String() ||
+		opts.Target == builder.TargetTypeFlatcar.String() {
+		if len(opts.KernelConfigData) == 0 {
+			level.ReportError(opts.KernelConfigData, "kernelConfigData", "KernelConfigData", "required_kernelconfigdata_with_target_vanilla", "")
+		}
 	}
 
 	if opts.KernelVersion == "" && (opts.Target == builder.TargetTypeUbuntu.String()) {

--- a/pkg/driverbuilder/builder/amazonlinux.go
+++ b/pkg/driverbuilder/builder/amazonlinux.go
@@ -62,26 +62,26 @@ type amazonlinuxTemplateData struct {
 	KernelDownloadURLs []string
 }
 
-func (a amazonlinux) Name() string {
+func (a *amazonlinux) Name() string {
 	return TargetTypeAmazonLinux.String()
 }
 
-func (a amazonlinux) TemplateScript() string {
+func (a *amazonlinux) TemplateScript() string {
 	return amazonlinuxTemplate
 }
 
-func (a amazonlinux) URLs(_ Config, kr kernelrelease.KernelRelease) ([]string, error) {
+func (a *amazonlinux) URLs(_ Config, kr kernelrelease.KernelRelease) ([]string, error) {
 	return fetchAmazonLinuxPackagesURLs(a, kr)
 }
 
-func (a amazonlinux) TemplateData(c Config, kr kernelrelease.KernelRelease, urls []string) interface{} {
+func (a *amazonlinux) TemplateData(c Config, kr kernelrelease.KernelRelease, urls []string) interface{} {
 	return amazonlinuxTemplateData{
-		commonTemplateData: c.toTemplateData(),
+		commonTemplateData: c.toTemplateData(a, kr),
 		KernelDownloadURLs: urls,
 	}
 }
 
-func (a amazonlinux) repos() []string {
+func (a *amazonlinux) repos() []string {
 	return []string{
 		"latest/updates",
 		"latest/main",
@@ -94,46 +94,46 @@ func (a amazonlinux) repos() []string {
 	}
 }
 
-func (a amazonlinux) baseUrl() string {
+func (a *amazonlinux) baseUrl() string {
 	return "http://repo.us-east-1.amazonaws.com"
 }
 
-func (a amazonlinux) ext() string {
+func (a *amazonlinux) ext() string {
 	return "bz2"
 }
 
-func (a amazonlinux2022) Name() string {
+func (a *amazonlinux2022) Name() string {
 	return TargetTypeAmazonLinux2022.String()
 }
 
-func (a amazonlinux2022) URLs(_ Config, kr kernelrelease.KernelRelease) ([]string, error) {
+func (a *amazonlinux2022) URLs(_ Config, kr kernelrelease.KernelRelease) ([]string, error) {
 	return fetchAmazonLinuxPackagesURLs(a, kr)
 }
 
-func (a amazonlinux2022) repos() []string {
+func (a *amazonlinux2022) repos() []string {
 	return []string{
 		"2022.0.20220202",
 		"2022.0.20220315",
 	}
 }
 
-func (a amazonlinux2022) baseUrl() string {
+func (a *amazonlinux2022) baseUrl() string {
 	return "https://al2022-repos-us-east-1-9761ab97.s3.dualstack.us-east-1.amazonaws.com/core/mirrors"
 }
 
-func (a amazonlinux2022) ext() string {
+func (a *amazonlinux2022) ext() string {
 	return "gz"
 }
 
-func (a amazonlinux2) Name() string {
+func (a *amazonlinux2) Name() string {
 	return TargetTypeAmazonLinux2.String()
 }
 
-func (a amazonlinux2) URLs(_ Config, kr kernelrelease.KernelRelease) ([]string, error) {
+func (a *amazonlinux2) URLs(_ Config, kr kernelrelease.KernelRelease) ([]string, error) {
 	return fetchAmazonLinuxPackagesURLs(a, kr)
 }
 
-func (a amazonlinux2) repos() []string {
+func (a *amazonlinux2) repos() []string {
 	return []string{
 		"core/2.0",
 		"core/latest",
@@ -142,22 +142,22 @@ func (a amazonlinux2) repos() []string {
 	}
 }
 
-func (a amazonlinux2) baseUrl() string {
+func (a *amazonlinux2) baseUrl() string {
 	return "http://amazonlinux.us-east-1.amazonaws.com/2"
 }
 
-func (a amazonlinux2) ext() string {
+func (a *amazonlinux2) ext() string {
 	return "gz"
 }
 
 func buildMirror(a amazonBuilder, r string, kv kernelrelease.KernelRelease) (string, error) {
 	var baseURL string
 	switch a.(type) {
-	case amazonlinux:
+	case *amazonlinux:
 		baseURL = fmt.Sprintf("%s/%s", a.baseUrl(), r)
-	case amazonlinux2:
+	case *amazonlinux2:
 		baseURL = fmt.Sprintf("%s/%s/%s", a.baseUrl(), r, kv.Architecture.ToNonDeb())
-	case amazonlinux2022:
+	case *amazonlinux2022:
 		baseURL = fmt.Sprintf("%s/%s/%s", a.baseUrl(), r, kv.Architecture.ToNonDeb())
 	default:
 		return "", fmt.Errorf("unsupported target")

--- a/pkg/driverbuilder/builder/archlinux.go
+++ b/pkg/driverbuilder/builder/archlinux.go
@@ -27,15 +27,15 @@ type archlinuxTemplateData struct {
 	KernelDownloadURL string
 }
 
-func (c archlinux) Name() string {
+func (c *archlinux) Name() string {
 	return TargetTypeArchlinux.String()
 }
 
-func (c archlinux) TemplateScript() string {
+func (c *archlinux) TemplateScript() string {
 	return archlinuxTemplate
 }
 
-func (c archlinux) URLs(cfg Config, kr kernelrelease.KernelRelease) ([]string, error) {
+func (c *archlinux) URLs(cfg Config, kr kernelrelease.KernelRelease) ([]string, error) {
 	urls := []string{}
 
 	if kr.Architecture == kernelrelease.ArchitectureAmd64 {
@@ -92,9 +92,9 @@ func (c archlinux) URLs(cfg Config, kr kernelrelease.KernelRelease) ([]string, e
 	return urls, nil
 }
 
-func (c archlinux) TemplateData(cfg Config, _ kernelrelease.KernelRelease, urls []string) interface{} {
+func (c *archlinux) TemplateData(cfg Config, kr kernelrelease.KernelRelease, urls []string) interface{} {
 	return archlinuxTemplateData{
-		commonTemplateData: cfg.toTemplateData(),
+		commonTemplateData: cfg.toTemplateData(c, kr),
 		KernelDownloadURL:  urls[0],
 	}
 }

--- a/pkg/driverbuilder/builder/centos.go
+++ b/pkg/driverbuilder/builder/centos.go
@@ -25,15 +25,15 @@ type centosTemplateData struct {
 	KernelDownloadURL string
 }
 
-func (c centos) Name() string {
+func (c *centos) Name() string {
 	return TargetTypeCentos.String()
 }
 
-func (c centos) TemplateScript() string {
+func (c *centos) TemplateScript() string {
 	return centosTemplate
 }
 
-func (c centos) URLs(_ Config, kr kernelrelease.KernelRelease) ([]string, error) {
+func (c *centos) URLs(_ Config, kr kernelrelease.KernelRelease) ([]string, error) {
 	vaultReleases := []string{
 		"6.0/os",
 		"6.0/updates",
@@ -160,9 +160,9 @@ func (c centos) URLs(_ Config, kr kernelrelease.KernelRelease) ([]string, error)
 	return urls, nil
 }
 
-func (c centos) TemplateData(cfg Config, _ kernelrelease.KernelRelease, urls []string) interface{} {
+func (c *centos) TemplateData(cfg Config, kr kernelrelease.KernelRelease, urls []string) interface{} {
 	return centosTemplateData{
-		commonTemplateData: cfg.toTemplateData(),
+		commonTemplateData: cfg.toTemplateData(c, kr),
 		KernelDownloadURL:  urls[0],
 	}
 }

--- a/pkg/driverbuilder/builder/debian.go
+++ b/pkg/driverbuilder/builder/debian.go
@@ -37,28 +37,28 @@ type debianTemplateData struct {
 type debian struct {
 }
 
-func (v debian) Name() string {
+func (v *debian) Name() string {
 	return TargetTypeDebian.String()
 }
 
-func (v debian) TemplateScript() string {
+func (v *debian) TemplateScript() string {
 	return debianTemplate
 }
 
-func (v debian) URLs(_ Config, kr kernelrelease.KernelRelease) ([]string, error) {
+func (v *debian) URLs(_ Config, kr kernelrelease.KernelRelease) ([]string, error) {
 	return fetchDebianKernelURLs(kr)
 }
 
-func (v debian) TemplateData(c Config, kr kernelrelease.KernelRelease, urls []string) interface{} {
+func (v *debian) TemplateData(c Config, kr kernelrelease.KernelRelease, urls []string) interface{} {
 	return debianTemplateData{
-		commonTemplateData: c.toTemplateData(),
+		commonTemplateData: c.toTemplateData(v, kr),
 		KernelDownloadURLS: urls,
 		KernelLocalVersion: kr.FullExtraversion,
 		KernelArch:         kr.Architecture.String(),
 	}
 }
 
-func (v debian) MinimumURLs() int {
+func (v *debian) MinimumURLs() int {
 	return debianRequiredURLs
 }
 

--- a/pkg/driverbuilder/builder/photon.go
+++ b/pkg/driverbuilder/builder/photon.go
@@ -25,21 +25,21 @@ type photonTemplateData struct {
 	KernelDownloadURL string
 }
 
-func (p photon) Name() string {
+func (p *photon) Name() string {
 	return TargetTypePhoton.String()
 }
 
-func (p photon) TemplateScript() string {
+func (p *photon) TemplateScript() string {
 	return photonTemplate
 }
 
-func (p photon) URLs(_ Config, kr kernelrelease.KernelRelease) ([]string, error) {
+func (p *photon) URLs(_ Config, kr kernelrelease.KernelRelease) ([]string, error) {
 	return fetchPhotonKernelURLS(kr), nil
 }
 
-func (p photon) TemplateData(cfg Config, kr kernelrelease.KernelRelease, urls []string) interface{} {
+func (p *photon) TemplateData(cfg Config, kr kernelrelease.KernelRelease, urls []string) interface{} {
 	return photonTemplateData{
-		commonTemplateData: cfg.toTemplateData(),
+		commonTemplateData: cfg.toTemplateData(p, kr),
 		KernelDownloadURL:  urls[0],
 	}
 }

--- a/pkg/driverbuilder/builder/redhat.go
+++ b/pkg/driverbuilder/builder/redhat.go
@@ -24,26 +24,26 @@ type redhatTemplateData struct {
 	KernelPackage string
 }
 
-func (v redhat) Name() string {
+func (v *redhat) Name() string {
 	return TargetTypeRedhat.String()
 }
 
-func (v redhat) TemplateScript() string {
+func (v *redhat) TemplateScript() string {
 	return redhatTemplate
 }
 
-func (v redhat) URLs(_ Config, _ kernelrelease.KernelRelease) ([]string, error) {
+func (v *redhat) URLs(_ Config, _ kernelrelease.KernelRelease) ([]string, error) {
 	return nil, nil
 }
 
-func (v redhat) MinimumURLs() int {
+func (v *redhat) MinimumURLs() int {
 	// We don't need any url
 	return 0
 }
 
-func (v redhat) TemplateData(c Config, kr kernelrelease.KernelRelease, _ []string) interface{} {
+func (v *redhat) TemplateData(c Config, kr kernelrelease.KernelRelease, _ []string) interface{} {
 	return redhatTemplateData{
-		commonTemplateData: c.toTemplateData(),
+		commonTemplateData: c.toTemplateData(v, kr),
 		KernelPackage:      kr.Fullversion + kr.FullExtraversion,
 	}
 }

--- a/pkg/driverbuilder/builder/rocky.go
+++ b/pkg/driverbuilder/builder/rocky.go
@@ -25,21 +25,21 @@ type rockyTemplateData struct {
 type rocky struct {
 }
 
-func (c rocky) Name() string {
+func (c *rocky) Name() string {
 	return TargetTypeRocky.String()
 }
 
-func (c rocky) TemplateScript() string {
+func (c *rocky) TemplateScript() string {
 	return rockyTemplate
 }
 
-func (c rocky) URLs(_ Config, kr kernelrelease.KernelRelease) ([]string, error) {
+func (c *rocky) URLs(_ Config, kr kernelrelease.KernelRelease) ([]string, error) {
 	return fetchRockyKernelURLS(kr), nil
 }
 
-func (c rocky) TemplateData(cfg Config, kr kernelrelease.KernelRelease, urls []string) interface{} {
+func (c *rocky) TemplateData(cfg Config, kr kernelrelease.KernelRelease, urls []string) interface{} {
 	return rockyTemplateData{
-		commonTemplateData: cfg.toTemplateData(),
+		commonTemplateData: cfg.toTemplateData(c, kr),
 		KernelDownloadURL:  urls[0],
 	}
 }

--- a/pkg/driverbuilder/builder/templates/flatcar.sh
+++ b/pkg/driverbuilder/builder/templates/flatcar.sh
@@ -20,9 +20,10 @@ rm -Rf /tmp/kernel
 mkdir -p /tmp/kernel
 mv /tmp/kernel-download/*/* /tmp/kernel
 
-curl --silent -o /tmp/kernel.config -SL {{ .KernelConfigURL }}
-
+# Prepare the kernel
 cd /tmp/kernel
+cp /driverkit/kernel.config /tmp/kernel.config
+
 sed -i -e 's|^\(EXTRAVERSION =\).*|\1 -flatcar|' Makefile
 make KCONFIG_CONFIG=/tmp/kernel.config oldconfig
 make KCONFIG_CONFIG=/tmp/kernel.config modules_prepare

--- a/pkg/driverbuilder/builder/ubuntu.go
+++ b/pkg/driverbuilder/builder/ubuntu.go
@@ -32,23 +32,23 @@ func init() {
 // ubuntu is a driverkit target.
 type ubuntu struct{}
 
-func (v ubuntu) Name() string {
+func (v *ubuntu) Name() string {
 	return TargetTypeUbuntu.String()
 }
 
-func (v ubuntu) TemplateScript() string {
+func (v *ubuntu) TemplateScript() string {
 	return ubuntuTemplate
 }
 
-func (v ubuntu) URLs(c Config, kr kernelrelease.KernelRelease) ([]string, error) {
+func (v *ubuntu) URLs(c Config, kr kernelrelease.KernelRelease) ([]string, error) {
 	return ubuntuHeadersURLFromRelease(kr, c.Build.KernelVersion)
 }
 
-func (v ubuntu) MinimumURLs() int {
+func (v *ubuntu) MinimumURLs() int {
 	return ubuntuRequiredURLs
 }
 
-func (v ubuntu) TemplateData(c Config, kr kernelrelease.KernelRelease, urls []string) interface{} {
+func (v *ubuntu) TemplateData(c Config, kr kernelrelease.KernelRelease, urls []string) interface{} {
 	// parse the flavor out of the kernelrelease extraversion
 	_, flavor := parseUbuntuExtraVersion(kr.Extraversion)
 
@@ -62,14 +62,14 @@ func (v ubuntu) TemplateData(c Config, kr kernelrelease.KernelRelease, urls []st
 	}
 
 	return ubuntuTemplateData{
-		commonTemplateData:   c.toTemplateData(),
+		commonTemplateData:   c.toTemplateData(v, kr),
 		KernelDownloadURLS:   urls,
 		KernelLocalVersion:   kr.FullExtraversion,
 		KernelHeadersPattern: headersPattern,
 	}
 }
 
-func (v ubuntu) GCCVersion(kr kernelrelease.KernelRelease) float64 {
+func (v *ubuntu) GCCVersion(kr kernelrelease.KernelRelease) float64 {
 	switch kr.Version {
 	case 3:
 		switch {

--- a/pkg/driverbuilder/builder/ubuntu_test.go
+++ b/pkg/driverbuilder/builder/ubuntu_test.go
@@ -297,7 +297,7 @@ func TestFetchUbuntuKernelURL(t *testing.T) {
 }
 
 func TestUbuntuGCCVersionFromKernelRelease(t *testing.T) {
-	b := ubuntu{}
+	b := &ubuntu{}
 	for _, test := range tests {
 		input := test.config
 		gotGCCVersion := b.GCCVersion(input)

--- a/pkg/driverbuilder/builder/vanilla.go
+++ b/pkg/driverbuilder/builder/vanilla.go
@@ -26,21 +26,21 @@ type vanillaTemplateData struct {
 	KernelLocalVersion string
 }
 
-func (v vanilla) Name() string {
+func (v *vanilla) Name() string {
 	return TargetTypeVanilla.String()
 }
 
-func (v vanilla) TemplateScript() string {
+func (v *vanilla) TemplateScript() string {
 	return vanillaTemplate
 }
 
-func (v vanilla) URLs(_ Config, kr kernelrelease.KernelRelease) ([]string, error) {
+func (v *vanilla) URLs(_ Config, kr kernelrelease.KernelRelease) ([]string, error) {
 	return []string{fetchVanillaKernelURLFromKernelVersion(kr)}, nil
 }
 
-func (v vanilla) TemplateData(c Config, kr kernelrelease.KernelRelease, urls []string) interface{} {
+func (v *vanilla) TemplateData(c Config, kr kernelrelease.KernelRelease, urls []string) interface{} {
 	return vanillaTemplateData{
-		commonTemplateData: c.toTemplateData(),
+		commonTemplateData: c.toTemplateData(v, kr),
 		KernelDownloadURL:  urls[0],
 		KernelLocalVersion: kr.FullExtraversion,
 	}

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -90,7 +90,7 @@ func init() {
 		"required_kernelconfigdata_with_target_vanilla",
 		T,
 		func(ut ut.Translator) error {
-			return ut.Add("required_kernelconfigdata_with_target_vanilla", "{0} is a required field when target is vanilla", true)
+			return ut.Add("required_kernelconfigdata_with_target_vanilla", "{0} is a required field when target is vanilla/minikube/flatcar", true)
 		},
 		func(ut ut.Translator, fe validator.FieldError) string {
 			t, _ := ut.T("required_kernelconfigdata_with_target_vanilla", "kernel config data") // fixme ? tag "name" does not work when used at struct level


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area pkg


**What this PR does / why we need it**:

Fix a crash in the flatcar builder; moreover, make it actually work.
Basically it is now the same as vanilla/minikube builders, with some small differences. It will now require `kernelconfigdata` option. That is much more smart than fetching the kernelconfigdata URL only to download it in the template script, considering that we already had a `kernelconfigdata` option in driverkit.

Moreover, moved all builder structs receivers to pointers, so that we can actually update any struct members in receiver methods.

Finally, actually require `kernelconfigdata` param for minikube and flatcar too.

This goes together with https://github.com/falcosecurity/kernel-crawler/pull/50.

**Which issue(s) this PR fixes**:

Flatcar crash + make it working.

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
fix(pkg): fixed flatcar builder crash and implementation
```
