### PR TITLE
add check for @PROBE

### DIFF
--- a/pkg/driverbuilder/templates.go
+++ b/pkg/driverbuilder/templates.go
@@ -85,6 +85,9 @@ func LoadMakefileObjList(c builder.Config) (string, error) {
 		if strings.HasPrefix(l, "@DRIVER_NAME@-y +=") {
 			return strings.Split(l, "@DRIVER_NAME@-y += ")[1], nil
 		}
+		if strings.HasPrefix(l, "@PROBE_NAME@-y +=") {
+            return strings.Split(l, "@PROBE_NAME@-y += ")[1], nil
+		}
 	}
 	return "", fmt.Errorf("obj list not found")
 }

--- a/pkg/driverbuilder/templates.go
+++ b/pkg/driverbuilder/templates.go
@@ -2,11 +2,12 @@ package driverbuilder
 
 import (
 	"fmt"
-	"github.com/falcosecurity/driverkit/pkg/driverbuilder/builder"
 	"io"
 	"net/http"
 	"strings"
 	"text/template"
+
+	"github.com/falcosecurity/driverkit/pkg/driverbuilder/builder"
 )
 
 var waitForLockScript = `
@@ -86,7 +87,7 @@ func LoadMakefileObjList(c builder.Config) (string, error) {
 			return strings.Split(l, "@DRIVER_NAME@-y += ")[1], nil
 		}
 		if strings.HasPrefix(l, "@PROBE_NAME@-y +=") {
-            return strings.Split(l, "@PROBE_NAME@-y += ")[1], nil
+			return strings.Split(l, "@PROBE_NAME@-y += ")[1], nil
 		}
 	}
 	return "", fmt.Errorf("obj list not found")


### PR DESCRIPTION
Signed-off-by: Logan Bond <lbond@secureworks.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area cmd

/area pkg

> /area docs

> /area tests


**What this PR does / why we need it**:
It appears that one some Falco libs versions modules fail to build with an error "obj list not found". When tracking down the error, it comes from this function:
```
func LoadMakefileObjList(c builder.Config) (string, error) {
    makefileUrl := fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s/driver/Makefile.in", c.RepoOrg, c.RepoName, c.DriverVersion)
    fmt.Println(makefileUrl)
    resp, err := http.Get(makefileUrl)
    if err != nil {
        return "", err
    }
    defer resp.Body.Close()
    parsedMakefile, err := io.ReadAll(resp.Body)
    if err != nil {
        return "", err
    }
    lines := strings.Split(string(parsedMakefile), "\n")
    fmt.Println(lines)
    for _, l := range lines {
        if strings.HasPrefix(l, "@DRIVER_NAME@-y +=") {
            return strings.Split(l, "@DRIVER_NAME@-y += ")[1], nil
        }
    }
    return "", fmt.Errorf("obj list not found")
}
```
The function returns correctly when it is able to parse `@DRIVER_NAME@` from the Makefile it pull down from GitHub. However, for some libs versions, that Makefile is different. Here's an example:

libs version 3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4: https://raw.githubusercontent.com/falcosecurity/libs/3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4/driver/Makefile.in

libs version 39ae7d40496793cf3d3e7890c9bbdc202263836: https://raw.githubusercontent.com/falcosecurity/libs/39ae7d40496793cf3d3e7890c9bbdc202263836b/driver/Makefile.in

For libs 3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4, the Makefile has `@PROBE_NAME`, not `@DRIVER_NAME`. This can be fixed by simply checking for both in the function, or by unifying the backend Makefiles that are pulled in (I think).

I am unsure of how to fix the backend Makefiles, but updating the function is easy enough 🙂 


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #221 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note

```
