### PR TITLE
Adjust `headersPattern` Detection for Ubuntu

### DIFF
--- a/pkg/driverbuilder/builder/templates/ubuntu.sh
+++ b/pkg/driverbuilder/builder/templates/ubuntu.sh
@@ -22,6 +22,7 @@ tar -xf data.tar.*
 {{end}}
 
 cd /tmp/kernel-download/usr/src/
+ls -altr
 sourcedir=$(find . -type d -name "{{ .KernelHeadersPattern }}" | head -n 1 | xargs readlink -f)
 
 {{ if .BuildModule }}

--- a/pkg/driverbuilder/builder/ubuntu.go
+++ b/pkg/driverbuilder/builder/ubuntu.go
@@ -59,7 +59,7 @@ func (v *ubuntu) TemplateData(c Config, kr kernelrelease.KernelRelease, urls []s
 	if flavor == "hwe" {
 		headersPattern = "linux-headers*generic"
 	} else {
-		// some flavors (ex: lowlatency-hwe) only contain the first part of the flavor in the  directory extracted from the .deb
+		// some flavors (ex: lowlatency-hwe) only contain the first part of the flavor in the directory extracted from the .deb
 		// splitting a flavor without a "-" should just return the original flavor back	
 		headersPattern = fmt.Sprintf("linux-headers*%s", strings.Split(flavor, "-")[0])
 	}

--- a/pkg/driverbuilder/builder/ubuntu.go
+++ b/pkg/driverbuilder/builder/ubuntu.go
@@ -59,8 +59,7 @@ func (v *ubuntu) TemplateData(c Config, kr kernelrelease.KernelRelease, urls []s
 	if flavor == "hwe" {
 		headersPattern = "linux-headers*generic"
 	} else {
-		// some flavors (ex: lowlatency-hwe) only contain the first part of the flavor in the
-		// directory extracted from the .deb
+		// some flavors (ex: lowlatency-hwe) only contain the first part of the flavor in the  directory extracted from the .deb
 		// splitting a flavor without a "-" should just return the original flavor back	
 		headersPattern = fmt.Sprintf("linux-headers*%s", strings.Split(flavor, "-")[0])
 	}

--- a/pkg/driverbuilder/builder/ubuntu.go
+++ b/pkg/driverbuilder/builder/ubuntu.go
@@ -59,7 +59,10 @@ func (v *ubuntu) TemplateData(c Config, kr kernelrelease.KernelRelease, urls []s
 	if flavor == "hwe" {
 		headersPattern = "linux-headers*generic"
 	} else {
-		headersPattern = fmt.Sprintf("linux-headers*%s", flavor)
+		// some flavors (ex: lowlatency-hwe) only contain the first part of the flavor in the
+		// directory extracted from the .deb
+		// splitting a flavor without a "-" should just return the original flavor back	
+		headersPattern = fmt.Sprintf("linux-headers*%s", strings.Split(flavor, "-")[0])
 	}
 
 	return ubuntuTemplateData{

--- a/pkg/driverbuilder/builder/ubuntu_test.go
+++ b/pkg/driverbuilder/builder/ubuntu_test.go
@@ -229,7 +229,7 @@ var tests = []struct {
 			flavor      string
 			err         error
 		}{
-			headersURLs: []string{"https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-kvm/linux-headers-5.19.0-1006-kvm_5.19.0-1006.6_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-kvm/linux-kvm-headers-5.19.0-1006_5.19.0-1006.6_all.deb"},
+			headersURLs: []string{},
 			urls:        []string{"https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-5.19.0-1006-kvm_5.19.0-1006.6_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-5.19.0-1006-kvm_5.19.0-1006.6_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-kvm-headers-5.19.0-1006_5.19.0-1006.6_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-kvm/linux-headers-5.19.0-1006-kvm_5.19.0-1006.6_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-kvm/linux-headers-5.19.0-1006-kvm_5.19.0-1006.6_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-kvm/linux-kvm-headers-5.19.0-1006_5.19.0-1006.6_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-kvm-5.19/linux-headers-5.19.0-1006-kvm_5.19.0-1006.6_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-kvm-5.19/linux-headers-5.19.0-1006-kvm_5.19.0-1006.6_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-kvm-5.19/linux-kvm-headers-5.19.0-1006_5.19.0-1006.6_all.deb"},
 			gccVersion: semver.Version{
 				Major: 12,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area cmd

/area pkg

> /area docs

> /area tests


**What this PR does / why we need it**:
Adjusting the `headersPattern` for Ubuntu. See #223 

Splitting the `flavor` on `-` should return just the first part of the flavor, which will still work for the `headersPattern`. If the `flavor` does not contain `-`, then it should just return the original `flavor` like normal.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #223 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note

```
