### PR TITLE
update: avoid building unfeasible kmods and probes

### DIFF
--- a/pkg/driverbuilder/builder/ubuntu_test.go
+++ b/pkg/driverbuilder/builder/ubuntu_test.go
@@ -2,8 +2,9 @@ package builder
 
 import (
 	"fmt"
-	"github.com/blang/semver"
 	"testing"
+
+	"github.com/blang/semver"
 
 	"github.com/falcosecurity/driverkit/pkg/kernelrelease"
 )
@@ -228,7 +229,7 @@ var tests = []struct {
 			flavor      string
 			err         error
 		}{
-			headersURLs: []string{"https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-kvm/linux-headers-5.19.0-1006-kvm_5.19.0-1006.6_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-kvm/linux-kvm-headers-5.19.0-1006_5.19.0-1006.6_all.deb"},
+			headersURLs: []string{},
 			urls:        []string{"https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-5.19.0-1006-kvm_5.19.0-1006.6_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-headers-5.19.0-1006-kvm_5.19.0-1006.6_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/linux-kvm-headers-5.19.0-1006_5.19.0-1006.6_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-kvm/linux-headers-5.19.0-1006-kvm_5.19.0-1006.6_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-kvm/linux-headers-5.19.0-1006-kvm_5.19.0-1006.6_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-kvm/linux-kvm-headers-5.19.0-1006_5.19.0-1006.6_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-kvm-5.19/linux-headers-5.19.0-1006-kvm_5.19.0-1006.6_amd64_all.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-kvm-5.19/linux-headers-5.19.0-1006-kvm_5.19.0-1006.6_amd64.deb", "https://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-kvm-5.19/linux-kvm-headers-5.19.0-1006_5.19.0-1006.6_all.deb"},
 			gccVersion: semver.Version{
 				Major: 12,

--- a/pkg/kernelrelease/kernelrelease.go
+++ b/pkg/kernelrelease/kernelrelease.go
@@ -32,12 +32,20 @@ var SupportedArchs = Architectures{
 var supportedArchsSlice []string
 
 // Represents the minimum kernel version for which building the module
-// is supported, depending on the architecture
-var moduleMinKernelVersion map[Architecture]semver.Version
+// is supported, depending on the architecture.
+// See compatibility matrix: https://falco.org/docs/event-sources/drivers/
+var moduleMinKernelVersion = map[Architecture]semver.Version{
+	ArchitectureAmd64: semver.MustParse("2.6.0"),
+	ArchitectureArm64: semver.MustParse("3.4.0"),
+}
 
 // Represents the minimum kernel version for which building the probe
-// is supported, depending on the architecture
-var probeMinKernelVersion map[Architecture]semver.Version
+// is supported, depending on the architecture.
+// See compatibility matrix: https://falco.org/docs/event-sources/drivers/
+var probeMinKernelVersion = map[Architecture]semver.Version{
+	ArchitectureAmd64: semver.MustParse("4.14.0"),
+	ArchitectureArm64: semver.MustParse("4.17.0"),
+}
 
 func init() {
 	i := 0
@@ -46,17 +54,6 @@ func init() {
 		supportedArchsSlice[i] = k.String()
 		i++
 	}
-
-	// see compatibility matrix: https://falco.org/docs/event-sources/drivers/
-	// note: this does not make much sense for flatcar, which has a much
-	// higher major version. In that case, we assume that the module/probe
-	// is always supported, and eventually fail while building
-	moduleMinKernelVersion = make(map[Architecture]semver.Version)
-	probeMinKernelVersion = make(map[Architecture]semver.Version)
-	moduleMinKernelVersion[ArchitectureAmd64] = semver.MustParse("2.6.0")
-	moduleMinKernelVersion[ArchitectureArm64] = semver.MustParse("3.4.0")
-	probeMinKernelVersion[ArchitectureAmd64] = semver.MustParse("4.14.0")
-	probeMinKernelVersion[ArchitectureArm64] = semver.MustParse("4.17.0")
 }
 
 func (aa Architectures) String() string {
@@ -126,9 +123,9 @@ func FromString(kernelVersionStr string) KernelRelease {
 }
 
 func (k *KernelRelease) SupportsModule() bool {
-	return k.Compare(moduleMinKernelVersion[k.Architecture]) >= 0
+	return k.GTE(moduleMinKernelVersion[k.Architecture])
 }
 
 func (k *KernelRelease) SupportsProbe() bool {
-	return k.Compare(probeMinKernelVersion[k.Architecture]) >= 0
+	return k.GTE(probeMinKernelVersion[k.Architecture])
 }

--- a/pkg/kernelrelease/kernelrelease_test.go
+++ b/pkg/kernelrelease/kernelrelease_test.go
@@ -1,8 +1,9 @@
 package kernelrelease
 
 import (
-	"github.com/blang/semver"
 	"testing"
+
+	"github.com/blang/semver"
 
 	"gotest.tools/assert"
 )
@@ -161,5 +162,133 @@ func TestFromString(t *testing.T) {
 			got := FromString(tt.kernelVersionStr)
 			assert.DeepEqual(t, tt.want, got)
 		})
+	}
+}
+
+func TestSupportsModule(t *testing.T) {
+	unsupported := []KernelRelease{
+		{
+			Version:      semver.Version{Major: 2, Minor: 5, Patch: 0},
+			Architecture: ArchitectureAmd64,
+		},
+		{
+			Version:      semver.Version{Major: 2, Minor: 5, Patch: 99},
+			Architecture: ArchitectureAmd64,
+		},
+		{
+			Version:      semver.Version{Major: 2, Minor: 6, Patch: 0},
+			Architecture: ArchitectureArm64,
+		},
+		{
+			Version:      semver.Version{Major: 3, Minor: 3, Patch: 99},
+			Architecture: ArchitectureArm64,
+		},
+		{
+			Version:      semver.Version{Major: 3, Minor: 3, Patch: 99},
+			Architecture: ArchitectureArm64,
+		},
+	}
+	supported := []KernelRelease{
+		{
+			Version:      semver.Version{Major: 2, Minor: 6, Patch: 0},
+			Architecture: ArchitectureAmd64,
+		},
+		{
+			Version:      semver.Version{Major: 2, Minor: 6, Patch: 1},
+			Architecture: ArchitectureAmd64,
+		},
+		{
+			Version:      semver.Version{Major: 3, Minor: 0, Patch: 0},
+			Architecture: ArchitectureAmd64,
+		},
+		{
+			Version:      semver.Version{Major: 5, Minor: 0, Patch: 0},
+			Architecture: ArchitectureAmd64,
+		},
+		{
+			Version:      semver.Version{Major: 3, Minor: 4, Patch: 0},
+			Architecture: ArchitectureArm64,
+		},
+		{
+			Version:      semver.Version{Major: 3, Minor: 4, Patch: 1},
+			Architecture: ArchitectureArm64,
+		},
+		{
+			Version:      semver.Version{Major: 5, Minor: 0, Patch: 0},
+			Architecture: ArchitectureArm64,
+		},
+	}
+
+	for _, r := range unsupported {
+		if r.SupportsModule() {
+			t.Errorf("building module should not be supported in kernel version %s", r.String())
+		}
+	}
+	for _, r := range supported {
+		if !r.SupportsModule() {
+			t.Errorf("building module should be supported in kernel version %s", r.String())
+		}
+	}
+}
+
+func TestSupportsProbe(t *testing.T) {
+	unsupported := []KernelRelease{
+		{
+			Version:      semver.Version{Major: 4, Minor: 13, Patch: 0},
+			Architecture: ArchitectureAmd64,
+		},
+		{
+			Version:      semver.Version{Major: 4, Minor: 13, Patch: 99},
+			Architecture: ArchitectureAmd64,
+		},
+		{
+			Version:      semver.Version{Major: 4, Minor: 14, Patch: 0},
+			Architecture: ArchitectureArm64,
+		},
+		{
+			Version:      semver.Version{Major: 4., Minor: 16, Patch: 0},
+			Architecture: ArchitectureArm64,
+		},
+		{
+			Version:      semver.Version{Major: 4, Minor: 16, Patch: 99},
+			Architecture: ArchitectureArm64,
+		},
+	}
+	supported := []KernelRelease{
+		{
+			Version:      semver.Version{Major: 4, Minor: 14, Patch: 0},
+			Architecture: ArchitectureAmd64,
+		},
+		{
+			Version:      semver.Version{Major: 4, Minor: 14, Patch: 1},
+			Architecture: ArchitectureAmd64,
+		},
+		{
+			Version:      semver.Version{Major: 5, Minor: 0, Patch: 0},
+			Architecture: ArchitectureAmd64,
+		},
+		{
+			Version:      semver.Version{Major: 4, Minor: 17, Patch: 0},
+			Architecture: ArchitectureArm64,
+		},
+		{
+			Version:      semver.Version{Major: 4, Minor: 17, Patch: 1},
+			Architecture: ArchitectureArm64,
+		},
+		{
+			Version:      semver.Version{Major: 5, Minor: 0, Patch: 0},
+			Architecture: ArchitectureArm64,
+		},
+	}
+
+	for _, r := range unsupported {
+		if r.SupportsProbe() {
+			t.Errorf("building probe should not be supported in kernel version %s", r.String())
+		}
+	}
+	for _, r := range supported {
+		if !r.SupportsProbe() {
+			t.Errorf("building probe should be supported in kernel version %s", r.String())
+		}
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area cmd

/area pkg

**What this PR does / why we need it**:

This updates the tool to figure out if the kmod and the eBPF probes are not supported on a given kernel release, so that we can avoid trying to build a config proven to be unfeasible. The goal is to save CPU and building time in the CI.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
update: avoid building unfeasible kmods and probes
```
