### PR TITLE
Forgot a `*` in the Ubuntu `headersPattern`

### DIFF
--- a/pkg/driverbuilder/builder/ubuntu.go
+++ b/pkg/driverbuilder/builder/ubuntu.go
@@ -61,7 +61,7 @@ func (v *ubuntu) TemplateData(c Config, kr kernelrelease.KernelRelease, urls []s
 	} else {
 		// some flavors (ex: lowlatency-hwe) only contain the first part of the flavor in the directory extracted from the .deb
 		// splitting a flavor without a "-" should just return the original flavor back	
-		headersPattern = fmt.Sprintf("linux-headers*%s", strings.Split(flavor, "-")[0])
+		headersPattern = fmt.Sprintf("linux-headers*%s*", strings.Split(flavor, "-")[0])
 	}
 
 	return ubuntuTemplateData{


### PR DESCRIPTION
Signed-off-by: Logan Bond <lbond@secureworks.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area cmd

/area pkg

> /area docs

> /area tests


**What this PR does / why we need it**:
Totally my bad, forgot a `*` on the end of the `headersPattern` to account for longer flavor names (as @dwindsor suggested).

Here are 2 examples I ran across in my testing that didn't work:
```
DEBU .+ cd /tmp/kernel-download/usr/src/
DEBU + ls -altr
DEBU total 16
DEBU drwxr-xr-x 24 root root 4096 Feb 23  2022 linux-intel-iotg-5.15-headers-5.15.0-1002
DEBU drwxr-xr-x  4 root root 4096 Feb 23  2022 ..
DEBU drwxr-xr-x  4 root root 4096 Feb 23  2022 .
DEBU drwxr-xr-x  7 root root 4096 Oct 20 20:44 linux-headers-5.15.0-1002-intel-iotg
DEBU ;++ find . -type d -name 'linux-headers*intel'
DEBU ++ head -n 1
DEBU ++ xargs readlink -f
DEBU Freadlink: missing operand
DEBU Try 'readlink --help' for more information.
```
and
```
DEBU .+ cd /tmp/kernel-download/usr/src/
DEBU + ls -altr
DEBU �total 16
DEBU drwxr-xr-x 24 root root 4096 Sep 12 16:24 linux-azure-cvm-headers-5.4.0-1091
DEBU drwxr-xr-x  4 root root 4096 Sep 12 16:24 ..
DEBU drwxr-xr-x  4 root root 4096 Sep 12 16:24 .
DEBU drwxr-xr-x  7 root root 4096 Oct 20 20:49 linux-headers-5.4.0-1091-azure-cvm
DEBU ;++ find . -type d -name 'linux-headers*azure'
DEBU ++ head -n 1
DEBU ++ xargs readlink -f
DEBU Freadlink: missing operand
DEBU Try 'readlink --help' for more information.
```

We still only care about the first part of the flavor, but if there are more parts, adding an ending `*` solves it.

Here's a test with the `*`:
```
DEBU .+ cd /tmp/kernel-download/usr/src/
DEBU + ls -altr
DEBU total 16
DEBU drwxr-xr-x 24 root root 4096 Feb 23  2022 linux-intel-iotg-5.15-headers-5.15.0-1002
DEBU drwxr-xr-x  4 root root 4096 Feb 23  2022 ..
DEBU drwxr-xr-x  4 root root 4096 Feb 23  2022 .
DEBU drwxr-xr-x  7 root root 4096 Oct 20 21:06 linux-headers-5.15.0-1002-intel-iotg
DEBU <++ find . -type d -name 'linux-headers*intel*'
DEBU ++ head -n 1
DEBU ++ xargs readlink -f
DEBU �+ sourcedir=/tmp/kernel-download/usr/src/linux-headers-5.15.0-1002-intel-iotg
DEBU + cd /tmp/driver
DEBU + make CC=/usr/bin/gcc-11 KERNELDIR=/tmp/kernel-download/usr/src/linux-headers-5.15.0-1002-intel-iotg
DEBU `make -C /tmp/kernel-download/usr/src/linux-headers-5.15.0-1002-intel-iotg M=/tmp/driver modules
DEBU `make[1]: Entering directory '/tmp/kernel-download/usr/src/linux-headers-5.15.0-1002-intel-iotg'
DEBU �warning: the compiler differs from the one used to build the kernel
DEBU   The kernel was built by: gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0
DEBU   You are using:           gcc-11 (Debian 11.3.0-8) 11.3.0
DEBU   CC [M]  /tmp/driver/main.o
# compile continues successfully...
```

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note

```
