### PR TITLE
Add Initial Fedora Support

### DIFF
--- a/pkg/driverbuilder/builder/fedora.go
+++ b/pkg/driverbuilder/builder/fedora.go
@@ -1,0 +1,74 @@
+package builder
+
+import (
+	_ "embed"
+	"fmt"
+	"strings"
+
+	"github.com/falcosecurity/driverkit/pkg/kernelrelease"
+)
+
+//go:embed templates/fedora.sh
+var fedoraTemplate string
+
+// TargetTypeFedora identifies the Fedora target.
+const TargetTypeFedora Type = "fedora"
+
+func init() {
+	BuilderByTarget[TargetTypeFedora] = &fedora{}
+}
+
+// fedora is a driverkit target.
+type fedora struct {
+}
+
+type fedoraTemplateData struct {
+	commonTemplateData
+	KernelDownloadURL string
+}
+
+func (c *fedora) Name() string {
+	return TargetTypeFedora.String()
+}
+
+func (c *fedora) TemplateScript() string {
+	return fedoraTemplate
+}
+
+func (c *fedora) URLs(_ Config, kr kernelrelease.KernelRelease) ([]string, error) {
+
+	// fedora FullExtraversion looks like "-200.fc36.x86_64"
+	// need to get the "fc36" out of the middle
+	fedoraVersion := strings.Split(kr.FullExtraversion, ".")[1]
+
+	// trim off the "fc" from fedoraVersion
+	version := strings.Trim(fedoraVersion, "fc")
+
+	// template the kernel info into all possible URL strings
+	urls := []string{
+		fmt.Sprintf( // updates
+			"https://mirrors.kernel.org/fedora/updates/%s/Everything/%s/Packages/k/kernel-devel-%s%s.rpm",
+			version,
+			kr.Architecture.ToNonDeb(),
+			kr.Fullversion,
+			kr.FullExtraversion,
+		),
+		fmt.Sprintf( // releases
+			"https://mirrors.kernel.org/fedora/releases/%s/Everything/%s/os/Packages/k/kernel-devel-%s%s.rpm",
+			version,
+			kr.Architecture.ToNonDeb(),
+			kr.Fullversion,
+			kr.FullExtraversion,
+		),
+	}
+
+	// return out all possible urls
+	return urls, nil
+}
+
+func (c *fedora) TemplateData(cfg Config, kr kernelrelease.KernelRelease, urls []string) interface{} {
+	return fedoraTemplateData{
+		commonTemplateData: cfg.toTemplateData(c, kr),
+		KernelDownloadURL:  urls[0],
+	}
+}

--- a/pkg/driverbuilder/builder/templates/fedora.sh
+++ b/pkg/driverbuilder/builder/templates/fedora.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -xeuo pipefail
+
+rm -Rf {{ .DriverBuildDir }}
+mkdir {{ .DriverBuildDir }}
+rm -Rf /tmp/module-download
+mkdir -p /tmp/module-download
+
+curl --silent -SL {{ .ModuleDownloadURL }} | tar -xzf - -C /tmp/module-download
+mv /tmp/module-download/*/driver/* {{ .DriverBuildDir }}
+
+cp /driverkit/module-Makefile {{ .DriverBuildDir }}/Makefile
+bash /driverkit/fill-driver-config.sh {{ .DriverBuildDir }}
+
+# Fetch the kernel
+mkdir /tmp/kernel-download
+cd /tmp/kernel-download
+curl --silent -o kernel-devel.rpm -SL {{ .KernelDownloadURL }}
+rpm2cpio kernel-devel.rpm | cpio --extract --make-directories
+rm -Rf /tmp/kernel
+mkdir -p /tmp/kernel
+mv usr/src/kernels/*/* /tmp/kernel
+
+{{ if .BuildModule }}
+# Build the module
+cd {{ .DriverBuildDir }}
+make CC=/usr/bin/gcc-{{ .GCCVersion }} KERNELDIR=/tmp/kernel
+mv {{ .ModuleDriverName }}.ko {{ .ModuleFullPath }}
+strip -g {{ .ModuleFullPath }}
+# Print results
+modinfo {{ .ModuleFullPath }}
+{{ end }}
+
+{{ if .BuildProbe }}
+# Build the eBPF probe
+cd {{ .DriverBuildDir }}/bpf
+make KERNELDIR=/tmp/kernel
+ls -l probe.o
+{{ end }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area cmd

/area pkg

> /area docs

> /area tests


**What this PR does / why we need it**:
Just adding initial Fedora support 🙂 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes # N/A

**Special notes for your reviewer**:
I tested these chages with kernel-crawler output:
```shell
╰─❯ kernel-crawler crawl --distro Fedora --out_fmt driverkit | jq -r '.Fedora[] | .kernelrelease'
Checking repositories  [####################################]  100%                                                       
Listing packages  [####################################]  100%                                                                               
5.11.12-300.fc34.x86_64
5.14.10-300.fc35.x86_64
5.17.5-300.fc36.x86_64
5.17.12-100.fc34.x86_64
5.19.16-100.fc35.x86_64
5.19.16-200.fc36.x86_64
```
...then ran each of those through like so:
```shell
╰─❯ _output/bin/driverkit docker --output-module ./test.ko --kernelrelease 5.14.10-300.fc35.x86_64 --target fedora -l debug
```

Only other thing of note: I just copied/pasted the `centos.sh` script to `fedora.sh` - it works for now, though Fedora may eventually update to change something since CentOs is going away.

**Does this PR introduce a user-facing change?**:
Adds Fedora!

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
Add Initial Fedora Support
```
