### PR TITLE
fix(pkg/kernelrelease): allow empty patch for kernelrelease strings.

### DIFF
--- a/pkg/kernelrelease/kernelrelease.go
+++ b/pkg/kernelrelease/kernelrelease.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	kernelVersionPattern = regexp.MustCompile(`(?P<fullversion>^(?P<version>0|[1-9]\d*)\.(?P<patchlevel>0|[1-9]\d*)\.(?P<sublevel>0|[1-9]\d*))(?P<fullextraversion>[-|.](?P<extraversion>0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)([\.+~](0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-_]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$`)
+	kernelVersionPattern = regexp.MustCompile(`(?P<fullversion>^(?P<version>0|[1-9]\d*)\.(?P<patchlevel>0|[1-9]\d*)\.?(?P<sublevel>0|[1-9]\d*)?)(?P<fullextraversion>[-|.](?P<extraversion>0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)([\.+~](0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-_]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$`)
 )
 
 const (
@@ -107,7 +107,11 @@ func FromString(kernelVersionStr string) KernelRelease {
 			case "patchlevel":
 				kv.Minor, err = strconv.ParseUint(match[i], 10, 64)
 			case "sublevel":
-				kv.Patch, err = strconv.ParseUint(match[i], 10, 64)
+				if len(match[i]) > 0 {
+					// We accept a missing sublevel (defaulting to 0)
+					// eg: 6.1.arch1-1
+					kv.Patch, err = strconv.ParseUint(match[i], 10, 64)
+				}
 			case "extraversion":
 				kv.Extraversion = match[i]
 			case "fullextraversion":


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area pkg

**What this PR does / why we need it**:

Some arch kernels are just named `6.1.arch1-1`. Therefore, allow empty patch level while parsing kernelrelease string.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
fix(pkg/kernelrelease): allow empty patch level string while parsing kernelrelease.
```
