### PR TITLE
fix(pkg/driverbuilder): rocky release urls

### DIFF
--- a/pkg/driverbuilder/builder/rocky.go
+++ b/pkg/driverbuilder/builder/rocky.go
@@ -47,10 +47,17 @@ func (c *rocky) TemplateData(cfg Config, kr kernelrelease.KernelRelease, urls []
 func fetchRockyKernelURLS(kr kernelrelease.KernelRelease) []string {
 	rockyReleases := []string{
 		"8",
+		"8.7",
+		"9",
+		"9.1",
+	}
+
+	rockyVaultReleases := []string{
+		"8.3",
+		"8.4",
 		"8.5",
 		"8.6",
-		"9",
-		"9.0",
+		"9.1",
 	}
 
 	urls := []string{}
@@ -63,9 +70,28 @@ func fetchRockyKernelURLS(kr kernelrelease.KernelRelease) []string {
 				kr.Fullversion,
 				kr.FullExtraversion,
 			))
-		}else{
+		} else {
 			urls = append(urls, fmt.Sprintf(
 				"https://download.rockylinux.org/pub/rocky/%s/BaseOS/%s/os/Packages/k/kernel-devel-%s%s.rpm",
+				r,
+				kr.Architecture.ToNonDeb(),
+				kr.Fullversion,
+				kr.FullExtraversion,
+			))
+		}
+	}
+	for _, r := range rockyVaultReleases {
+		if r >= "9" {
+			urls = append(urls, fmt.Sprintf(
+				"https://download.rockylinux.org/vault/rocky/%s/AppStream/%s/os/Packages/k/kernel-devel-%s%s.rpm",
+				r,
+				kr.Architecture.ToNonDeb(),
+				kr.Fullversion,
+				kr.FullExtraversion,
+			))
+		} else {
+			urls = append(urls, fmt.Sprintf(
+				"https://download.rockylinux.org/vault/rocky/%s/BaseOS/%s/os/Packages/k/kernel-devel-%s%s.rpm",
 				r,
 				kr.Architecture.ToNonDeb(),
 				kr.Fullversion,


### PR DESCRIPTION
```
Break out the vault releases from the mainstream releases, and append them all to the url list
```

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area pkg

**What this PR does / why we need it**:

Rocky Linux uses two different areas for their packages based on whether its a current release version or a previous.  The previous ones are put at a vault url, so the update was required to add a separate list of vault releases to support when looking for the urls to find the kernel-devel package.

**Which issue(s) this PR fixes**:

Fixes #245 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
