### PR TITLE
fix(pkg/kernelrelease): allow plus char as sublevel and extra separator

### DIFF
--- a/pkg/kernelrelease/kernelrelease.go
+++ b/pkg/kernelrelease/kernelrelease.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	kernelVersionPattern = regexp.MustCompile(`(?P<fullversion>^(?P<version>0|[1-9]\d*)\.(?P<patchlevel>0|[1-9]\d*)\.?(?P<sublevel>0|[1-9]\d*)?)(?P<fullextraversion>[-|.](?P<extraversion>0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)([\.+~](0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-_]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$`)
+	kernelVersionPattern = regexp.MustCompile(`(?P<fullversion>^(?P<version>0|[1-9]\d*)\.(?P<patchlevel>0|[1-9]\d*)[.+]?(?P<sublevel>0|[1-9]\d*)?)(?P<fullextraversion>[-.+](?P<extraversion>0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)([\.+~](0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-_]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$`)
 )
 
 const (

--- a/pkg/kernelrelease/kernelrelease_test.go
+++ b/pkg/kernelrelease/kernelrelease_test.go
@@ -195,6 +195,19 @@ func TestFromString(t *testing.T) {
 				FullExtraversion: "-1~deb10u3-amd64",
 			},
 		},
+		"strange Debian version 4": {
+			kernelVersionStr: "4.19+105+deb10u4~bpo9+1",
+			want: KernelRelease{
+				Fullversion: "4.19+105",
+				Version: semver.Version{
+					Major: 4,
+					Minor: 19,
+					Patch: 105,
+				},
+				Extraversion:     "deb10u4",
+				FullExtraversion: "+deb10u4~bpo9+1",
+			},
+		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
This PR will further improve the way kernel release names are parsed.
This is the case of distributions like Debian which applies a semantic for which a separator can be the the plus character ('+').

For example, with this change, a release named '4.19+105+deb10u4~bpo9+1' will be matched and the change will allow parsing by capturing the resulting regular expression named capturing groups.

Signed-off-by: Massimiliano Giovagnoli <me@maxgio.it>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area pkg

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #247 

**Special notes for your reviewer**:

NA

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
