### PR TITLE
fix(pkg): minimum kver to build kmod for arm64 is 3.16.

### DIFF
--- a/pkg/kernelrelease/kernelrelease.go
+++ b/pkg/kernelrelease/kernelrelease.go
@@ -36,7 +36,7 @@ var supportedArchsSlice []string
 // See compatibility matrix: https://falco.org/docs/event-sources/drivers/
 var moduleMinKernelVersion = map[Architecture]semver.Version{
 	ArchitectureAmd64: semver.MustParse("2.6.0"),
-	ArchitectureArm64: semver.MustParse("3.4.0"),
+	ArchitectureArm64: semver.MustParse("3.16.0"),
 }
 
 // Represents the minimum kernel version for which building the probe

--- a/pkg/kernelrelease/kernelrelease_test.go
+++ b/pkg/kernelrelease/kernelrelease_test.go
@@ -232,11 +232,7 @@ func TestSupportsModule(t *testing.T) {
 			Architecture: ArchitectureArm64,
 		},
 		{
-			Version:      semver.Version{Major: 3, Minor: 3, Patch: 99},
-			Architecture: ArchitectureArm64,
-		},
-		{
-			Version:      semver.Version{Major: 3, Minor: 3, Patch: 99},
+			Version:      semver.Version{Major: 3, Minor: 15, Patch: 99},
 			Architecture: ArchitectureArm64,
 		},
 	}
@@ -258,11 +254,11 @@ func TestSupportsModule(t *testing.T) {
 			Architecture: ArchitectureAmd64,
 		},
 		{
-			Version:      semver.Version{Major: 3, Minor: 4, Patch: 0},
+			Version:      semver.Version{Major: 3, Minor: 16, Patch: 0},
 			Architecture: ArchitectureArm64,
 		},
 		{
-			Version:      semver.Version{Major: 3, Minor: 4, Patch: 1},
+			Version:      semver.Version{Major: 3, Minor: 16, Patch: 1},
 			Architecture: ArchitectureArm64,
 		},
 		{


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area pkg

**What this PR does / why we need it**:

See https://github.com/falcosecurity/libs/pull/843

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
