### PR TITLE
feat: support amazonlinux2 5.15.x kernel

### DIFF
--- a/pkg/driverbuilder/builder/amazonlinux.go
+++ b/pkg/driverbuilder/builder/amazonlinux.go
@@ -139,6 +139,7 @@ func (a *amazonlinux2) repos() []string {
 		"core/latest",
 		"extras/kernel-5.4/latest",
 		"extras/kernel-5.10/latest",
+		"extras/kernel-5.15/latest",
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Austin Brogle <abrogle@snapchat.com>

**What type of PR is this?**
/kind feature


**Any specific area of the project related to this PR?**
/area pkg

**What this PR does / why we need it**:
Previously when running:
```bash
driverkit docker --builderimage docker.io/falcosecurity/driverkit-builder_bookworm:v0.11.1 --output-probe ./falco_amazonlinux2_5.15.43-20.123.amzn2.aarch64_1.o --architecture=arm64 --kernelversion=1 --kernelrelease=5.15.43-20.123.amzn2.aarch64 --driverversion=3.0.1+driver --target amazonlinux2 -l debug --timeout 480
```

I would get:
```
DEBU running without a configuration file
DEBU running with options                          arch=arm64 driverversion=3.0.1+driver kernelrelease=5.15.43-20.123.amzn2.aarch64 kernelversion=1 output-probe=/snap_scripts/output_probes/3.0.1+driver/falco_amazonlinux2_5.15.43-20.123.amzn2.aarch64_1.o repo-name=libs repo-org=falcosecurity target=amazonlinux2
INFO driver building, it will take a few seconds   processor=docker
DEBU doing a new docker build
DEBU looking for repo...                           url="http://amazonlinux.us-east-1.amazonaws.com/2/core/2.0/aarch64/mirror.list" version=core/2.0
DEBU downloading...                                url="http://amazonlinux.us-east-1.amazonaws.com/2/core/2.0/aarch64/fea80ba4bc71f0af6bb832225402464d1a607e9e616194a3d939b3cb9d6d1888/repodata/primary.sqlite.gz"
DEBU connecting to database...                     db=/tmp/amazonlinux2-1135566916.sqlite
DEBU looking for repo...                           url="http://amazonlinux.us-east-1.amazonaws.com/2/core/latest/aarch64/mirror.list" version=core/latest
DEBU looking for repo...                           url="http://amazonlinux.us-east-1.amazonaws.com/2/extras/kernel-5.4/latest/aarch64/mirror.list" version=extras/kernel-5.4/latest
DEBU downloading...                                url="http://amazonlinux.us-east-1.amazonaws.com/2/extras/kernel-5.4/stable/aarch64/6675b4f1d3e804c6719989e239c928745327d6d6f379a46918fbf5982740a636/repodata/primary.sqlite.gz"
DEBU connecting to database...                     db=/tmp/amazonlinux2-1029385813.sqlite
DEBU looking for repo...                           url="http://amazonlinux.us-east-1.amazonaws.com/2/extras/kernel-5.10/latest/aarch64/mirror.list" version=extras/kernel-5.10/latest
DEBU downloading...                                url="http://amazonlinux.us-east-1.amazonaws.com/2/extras/kernel-5.10/stable/aarch64/6c1ab0a0ebb087c246e01701544fa076da526dbda6dd94a57cce2cd781ee63e9/repodata/primary.sqlite.gz"
DEBU connecting to database...                     db=/tmp/amazonlinux2-1577867500.sqlite
FATA exiting                                       error="not enough headers packages found; expected 1, found 0"
```

With this additional repo for 5.15 it now builds the probe properly.


**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
No

```release-note
NONE
```
