### PR TITLE
cleanup: removed `builderrepo` option pointing to my dockerhub.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ integration_test: $(test_configs)
 
 .PHONY: $(test_configs)
 $(test_configs): ${driverkit}
-	${driverkit} docker -c $@ --builderimage auto:master -l debug --timeout 600 --builderrepo docker.io/fededp/driverkit
+	${driverkit} docker -c $@ --builderimage auto:master -l debug --timeout 600
 
 .PHONY: ${driverkit_docgen}
 ${driverkit_docgen}: ${PWD}/docgen


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area tests

**What this PR does / why we need it**:

#244 added a `builderrepo` option poiting at my dockerhub repo to tests, to allow them to pass.
Clean it up now that we have falcosecurity images.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
