### PR TITLE
Fixing Image Name Validation for Builder Image Flag

### DIFF
--- a/docker/builders/builder-any-x86_64_gcc8.0.0_gcc6.0.0_gcc5.0.0_gcc4.9.0_gcc4.8.0.Dockerfile
+++ b/docker/builders/builder-any-x86_64_gcc8.0.0_gcc6.0.0_gcc5.0.0_gcc4.9.0_gcc4.8.0.Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update \
 	gpg \
 	zstd \
 	gawk \
+	mawk \
     && rm -rf /var/lib/apt/lists/*
 
 RUN if [ "$TARGETARCH" = "amd64" ] ; then apt-get install -y --no-install-recommends libmpx2; fi

--- a/validate/isimagename.go
+++ b/validate/isimagename.go
@@ -1,8 +1,10 @@
 package validate
 
 import (
-	"github.com/go-playground/validator/v10"
 	"strings"
+	"unicode"
+
+	"github.com/go-playground/validator/v10"
 )
 
 const letters = "abcdefghijklmnopqrstuvwxyz"
@@ -14,7 +16,7 @@ func isImageName(fl validator.FieldLevel) bool {
 	name := fl.Field().String()
 
 	for _, c := range name {
-		if !strings.ContainsRune(alphabet, c) {
+		if !strings.ContainsRune(alphabet, unicode.ToLower(c)) {
 			return false
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area cmd

> /area pkg

> /area docs

> /area tests


**What this PR does / why we need it**:

We have some builder images that use uppercase characters in the tag name. For example:
```
example.com/oraclelinux7:AG-8537-oracle-support
```

These fail the validation on `--builderimage` due to the uppercase characters. The alphabet used for validation is locked to lowercase.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes # N/A

**Special notes for your reviewer**:

Also added `mawk` to the builderimage, which is required by some Oracle distros... And since these are Debian, `gawk` wasn't enough - Debian uses `mawk` haha

**Does this PR introduce a user-facing change?**:
N/A
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
