### PR TITLE
Adjust GCC 12 Selector to Kernels 5.15+

### DIFF
--- a/pkg/driverbuilder/builder/builders.go
+++ b/pkg/driverbuilder/builder/builders.go
@@ -4,14 +4,15 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/blang/semver"
-	"github.com/falcosecurity/driverkit/pkg/kernelrelease"
 	"log"
 	"net/http"
 	"net/url"
 	"path"
 	"strings"
 	"text/template"
+
+	"github.com/blang/semver"
+	"github.com/falcosecurity/driverkit/pkg/kernelrelease"
 
 	logger "github.com/sirupsen/logrus"
 )
@@ -122,7 +123,7 @@ type GCCVersionRequestor interface {
 func defaultGCC(kr kernelrelease.KernelRelease) semver.Version {
 	switch kr.Major {
 	case 5:
-		if kr.Minor >= 18 {
+		if kr.Minor >= 15 {
 			return semver.Version{Major: 12}
 		}
 		return semver.Version{Major: 11}

--- a/pkg/driverbuilder/builder/builders_test.go
+++ b/pkg/driverbuilder/builder/builders_test.go
@@ -1,9 +1,10 @@
 package builder
 
 import (
+	"testing"
+
 	"github.com/blang/semver"
 	"github.com/falcosecurity/driverkit/pkg/kernelrelease"
-	"testing"
 )
 
 var gccTests = []struct {
@@ -39,7 +40,7 @@ var gccTests = []struct {
 			Architecture:     kernelrelease.ArchitectureAmd64,
 		},
 		expectedGCC: semver.Version{
-			Major: 11,
+			Major: 12,
 		},
 	},
 	{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area cmd

/area pkg

> /area docs

> /area tests


**What this PR does / why we need it**:

Simply adjusting the GCC selector to use GCC 12 for kernels 5.15+ rather than just 5.18+

We noticed some issues in our infrastructure where GCC 11 was selected for kernels 5.15.x for Oracle, and none of them build. Adding the `--gccversion 12.0.0` flag fixes the builds. 

To then test that changing 5.15+ to GCC 12 doesn't break anything else, I deleted all 5.15.x kernels in our dev environment to rebuild them with the `--gccversion 12.0.0` flag. They also all build successfully. So I believe we're fine to tune this here to use GCC 12 for 5.15.x kernels.

Some examples where GCC 12 works for 5.15.x kernels:

```
# AmazonLinux2
[ 2023-04-06 15:31:22,132 ] DEBUG - driverkit.py:167 - Calling driverkit with command:
driverkit docker --output-module output/amazonlinux2/scwx_amzn_5.15.90-54.138.amzn2.x86_64_1.ko --kernelrelease 5.15.90-54.138.amzn2.x86_64 --kernelversion 1 --driverversion 4.0.0+driver --target amazonlinux2 --moduledevicename scwx-falco --moduledrivername scwx-falco --gccversion 12.0.0 --kernelurls [http://amazonlinux.us-east-1.amazonaws.com/2/extras/kernel-5.15/stable/x86_64/a27e12ba8d9383eb42e4d3946fcd0ecc7ed125a11c37c71ea48649698295232e/../../../../../../blobstore/a44135d50d0fe237e7e55da22f26b5c24ce4d6202cf78f8a1fe0ce6ba01c386e/kernel-devel-5.15.90-54.138.amzn2.x86_64.rpm](http://amazonlinux.us-east-1.amazonaws.com/blobstore/a44135d50d0fe237e7e55da22f26b5c24ce4d6202cf78f8a1fe0ce6ba01c386e/kernel-devel-5.15.90-54.138.amzn2.x86_64.rpm)
INFO driver building, it will take a few seconds   processor=docker
INFO kernel module available                       path=output/amazonlinux2/scwx_amzn_5.15.90-54.138.amzn2.x86_64_1.ko

# OracleLinux
[ 2023-04-06 15:10:06,246 ] DEBUG - driverkit.py:167 - Calling driverkit with command:
driverkit docker --output-module output/ol/scwx_ol_5.15.0-0.30.19.el8uek.x86_64_1.ko --kernelrelease 5.15.0-0.30.19.el8uek.x86_64 --kernelversion 1 --driverversion 4.0.0+driver --target ol --moduledevicename scwx-falco --moduledrivername scwx-falco --gccversion 12.0.0 --kernelurls http://yum.oracle.com/repo/OracleLinux/OL8/UEKR7/x86_64/getPackage/kernel-uek-devel-5.15.0-0.30.19.el8uek.x86_64.rpm
INFO driver building, it will take a few seconds   processor=docker
INFO kernel module available                       path=output/ol/scwx_ol_5.15.0-0.30.19.el8uek.x86_64_1.ko

# Ubuntu
driverkit docker --output-module output/ubuntu/scwx_ubuntu_5.15.0-1012-gcp_17~20.04.1.ko --kernelrelease 5.15.0-1012-gcp-5.15 --kernelversion 17~20.04.1 --driverversion 4.0.0+driver --target ubuntu --moduledevicename scwx-falco --moduledrivername scwx-falco --gccversion 12.0.0 --kernelurls http://security.ubuntu.com/ubuntu/pool/main/l/linux-gcp-5.15/linux-gcp-5.15-headers-5.15.0-1012_5.15.0-1012.17~20.04.1_amd64.deb --kernelurls http://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-gcp-5.15/linux-gcp-5.15-headers-5.15.0-1012_5.15.0-1012.17~20.04.1_amd64.deb --kernelurls http://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux-gcp-5.15/linux-headers-5.15.0-1012-gcp_5.15.0-1012.17~20.04.1_amd64.deb --kernelurls http://security.ubuntu.com/ubuntu/pool/main/l/linux-gcp-5.15/linux-headers-5.15.0-1012-gcp_5.15.0-1012.17~20.04.1_amd64.deb
INFO driver building, it will take a few seconds   processor=docker
INFO kernel module available                       path="output/ubuntu/scwx_ubuntu_5.15.0-1012-gcp_17~20.04.1.ko"
```
**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes # N/A

**Special notes for your reviewer**:

N/A

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
