### PR TITLE
new(pkg): support RC releases for vanilla target.

### DIFF
--- a/pkg/driverbuilder/builder/templates/vanilla.sh
+++ b/pkg/driverbuilder/builder/templates/vanilla.sh
@@ -15,7 +15,11 @@ bash /driverkit/fill-driver-config.sh {{ .DriverBuildDir }}
 # Fetch the kernel
 cd /tmp
 mkdir /tmp/kernel-download
+{{ if .IsTarGz}}
+curl --silent -SL {{ .KernelDownloadURL }} | tar -zxf - -C /tmp/kernel-download
+{{ else }}
 curl --silent -SL {{ .KernelDownloadURL }} | tar -Jxf - -C /tmp/kernel-download
+{{ end }}
 rm -Rf /tmp/kernel
 mkdir -p /tmp/kernel
 mv /tmp/kernel-download/*/* /tmp/kernel

--- a/pkg/driverbuilder/builder/vanilla.go
+++ b/pkg/driverbuilder/builder/vanilla.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"fmt"
 	"github.com/falcosecurity/driverkit/pkg/kernelrelease"
+	"strings"
 )
 
 //go:embed templates/vanilla.sh
@@ -24,6 +25,7 @@ type vanillaTemplateData struct {
 	commonTemplateData
 	KernelDownloadURL  string
 	KernelLocalVersion string
+	IsTarGz            bool
 }
 
 func (v *vanilla) Name() string {
@@ -43,9 +45,20 @@ func (v *vanilla) TemplateData(c Config, kr kernelrelease.KernelRelease, urls []
 		commonTemplateData: c.toTemplateData(v, kr),
 		KernelDownloadURL:  urls[0],
 		KernelLocalVersion: kr.FullExtraversion,
+		IsTarGz:            strings.HasSuffix(urls[0], ".tar.gz"), // Since RC have a tar.gz format, we need to inform the build script
 	}
 }
 
 func fetchVanillaKernelURLFromKernelVersion(kv kernelrelease.KernelRelease) string {
+	// Note: even non RC are available as tar.gz; but tar.xz are much smaller
+	// and thus much quicker to download. Let's keep tar.xz for non RC!
+	// Numbers: 110M (tar.gz) vs 75M (tar.xz)
+	if isRC(kv) {
+		return fmt.Sprintf("https://git.kernel.org/torvalds/t/linux-%s%s.tar.gz", kv.Fullversion, kv.FullExtraversion)
+	}
 	return fmt.Sprintf("https://cdn.kernel.org/pub/linux/kernel/v%d.x/linux-%s.tar.xz", kv.Major, kv.Fullversion)
+}
+
+func isRC(kv kernelrelease.KernelRelease) bool {
+	return strings.Contains(kv.Extraversion, "rc")
 }

--- a/pkg/kernelrelease/kernelrelease_test.go
+++ b/pkg/kernelrelease/kernelrelease_test.go
@@ -26,6 +26,18 @@ func TestFromString(t *testing.T) {
 				FullExtraversion: "-arch1-1",
 			},
 		},
+		"version RC": {
+			kernelVersionStr: "6.4-rc1",
+			want: KernelRelease{
+				Fullversion: "6.4",
+				Version: semver.Version{
+					Major: 6,
+					Minor: 4,
+				},
+				Extraversion:     "rc1",
+				FullExtraversion: "-rc1",
+			},
+		},
 		"just kernel version": {
 			kernelVersionStr: "5.5.2",
 			want: KernelRelease{


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area pkg

**What this PR does / why we need it**:

This PR adds support for release candidates for vanilla target.
Is going to be used to improve libs [`latest-kernel`](https://github.com/falcosecurity/libs/blob/master/.github/workflows/latest-kernel.yml) CI to test the build against latest mainline kernel available (RCs too!), so that we get notified asap when a kernel breaks our drivers build! :) 
See: https://github.com/falcosecurity/libs/pull/1090

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
new(pkg): support RC releases for vanilla target
```
