### PR TITLE
Adjust CentOS 4.18+ Kernels to use GCC 9

### DIFF
--- a/pkg/driverbuilder/builder/centos.go
+++ b/pkg/driverbuilder/builder/centos.go
@@ -3,6 +3,7 @@ package builder
 import (
 	_ "embed"
 	"fmt"
+
 	"github.com/blang/semver"
 	"github.com/falcosecurity/driverkit/pkg/kernelrelease"
 )
@@ -169,6 +170,10 @@ func (c *centos) TemplateData(cfg Config, kr kernelrelease.KernelRelease, urls [
 }
 
 func (c *centos) GCCVersion(kr kernelrelease.KernelRelease) semver.Version {
+	// 4.18+ centos 8 kernels need gcc 9
+	if kr.Major == 4 && kr.Minor >= 18 {
+		return semver.Version{Major: 9}
+	}
 	// 3.10.X kernels need 4.8.5 gcc version; see:
 	// https://github.com/falcosecurity/driverkit/issues/236
 	if kr.Major == 3 && kr.Minor == 10 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area cmd

> /area pkg

> /area docs

> /area tests


**What this PR does / why we need it**:

We have a lot of failures for CentOS 4.18.x kernels. It seems that the image selector defaults them to GCC 8. I bumped them up to the GCC 9 image, and now it works locally. For example:

```
_output/bin/driverkit docker --output-module _output/scwx_centos_4.18.0-490.el8.x86_64_1.ko --kernelrelease 4.18.0-490.el8.x86_64 --kernelversion 1 --driverversion 4.0.0+driver --target centos --moduledevicename scwx-falco --moduledrivername scwx-falco --kernelurls http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/kernel-devel-4.18.0-490.el8.x86_64.rpm --builderimage docker.io/falcosecurity/driverkit-builder:any-x86_64_gcc10.0.0_gcc9.0.0-246e90f
```
^ works now :)

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes # N/A

**Special notes for your reviewer**:

I only adjusted this in the CentOS builder, unsure this is universally true for all 4.18.x kernels. Also the change may be working because using GCC 9 bumps the builder image up to the GCC 9 image, which is based on bullseye rather than buster. Buster's build image has older versions of cpio/rpm2cpio, which had lower limits on how big rpms could be to unpack. Bullseye's version of these packages for managing rpms allows for bigger rpm file sizes.

Either way, the builds work now haha.

**Does this PR introduce a user-facing change?**:

Not really.

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
