### PR TITLE
fix(pkg): fixed mainline kernel URLs.

### DIFF
--- a/pkg/driverbuilder/builder/templates/vanilla.sh
+++ b/pkg/driverbuilder/builder/templates/vanilla.sh
@@ -36,6 +36,8 @@ make KCONFIG_CONFIG=/tmp/kernel.config oldconfig
 make KCONFIG_CONFIG=/tmp/kernel.config prepare
 make KCONFIG_CONFIG=/tmp/kernel.config modules_prepare
 
+export KBUILD_MODPOST_WARN=1
+
 {{ if .BuildModule }}
 # Build the kernel module
 cd {{ .DriverBuildDir }}

--- a/pkg/driverbuilder/builder/vanilla.go
+++ b/pkg/driverbuilder/builder/vanilla.go
@@ -54,7 +54,7 @@ func fetchVanillaKernelURLFromKernelVersion(kv kernelrelease.KernelRelease) stri
 	// and thus much quicker to download. Let's keep tar.xz for non RC!
 	// Numbers: 110M (tar.gz) vs 75M (tar.xz)
 	if isRC(kv) {
-		return fmt.Sprintf("https://git.kernel.org/torvalds/t/linux-%s%s.tar.gz", kv.Fullversion, kv.FullExtraversion)
+		return fmt.Sprintf("https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/snapshot/linux-%s%s.tar.gz", kv.Fullversion, kv.FullExtraversion)
 	}
 	return fmt.Sprintf("https://cdn.kernel.org/pub/linux/kernel/v%d.x/linux-%s.tar.xz", kv.Major, kv.Fullversion)
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area pkg


**What this PR does / why we need it**:

Moreover, properly enforce KBUILD_MODPOST_WARN in vanilla template.
It was previously enabled by default; but this commit: https://github.com/torvalds/linux/commit/5573b4daa26a0cf15aa0fecd7f1be16e0b6157bc merged in linux 6.3, changed the behavior.
Thus we now need to enforce it.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
