### PR TITLE
Add KCFLAG for CentOS to Fix Builds of Some Modules

### DIFF
--- a/pkg/driverbuilder/builder/templates/centos.sh
+++ b/pkg/driverbuilder/builder/templates/centos.sh
@@ -24,6 +24,7 @@ mv usr/src/kernels/*/* /tmp/kernel
 {{ if .BuildModule }}
 # Build the module
 cd {{ .DriverBuildDir }}
+sed -i 's/make -C $(KERNELDIR)/make KCFLAGS="-Wno-incompatible-pointer-types" -C $(KERNELDIR)/g' Makefile
 make CC=/usr/bin/gcc-{{ .GCCVersion }} KERNELDIR=/tmp/kernel
 mv {{ .ModuleDriverName }}.ko {{ .ModuleFullPath }}
 strip -g {{ .ModuleFullPath }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area cmd

> /area pkg

> /area docs

> /area tests


**What this PR does / why we need it**:

We've noticed some failures with recent CentOS 5.14.x kernels:
```
    [
        "scwx_centos_5.14.0-331.el9.x86_64_1.ko",
        "scwx_centos_5.14.0-333.el9.x86_64_1.ko",
        "scwx_centos_5.14.0-330.el9.x86_64_1.ko",
        "scwx_centos_5.14.0-325.el9.x86_64_1.ko",
        "scwx_centos_5.14.0-319.el9.x86_64_1.ko"
    ],
```
They fail with this error: 
```
DEBU *make -C /tmp/kernel M=/tmp/driver modules
DEBU *make[1]: Entering directory '/tmp/kernel'
DEBU   CC [M]  /tmp/driver/main.o
DEBU -/tmp/driver/main.c: In function 'scap_init':
DEBU /tmp/driver/main.c:2790:30: error: assignment to 'char * (*)(const struct device *, umode_t *)' {aka 'char * (*)(const struct device *, short unsigned int *)'} from incompatible pointer type 'char * (*)(struct device *, umode_t *)' {aka 'char * (*)(struct device *, short unsigned int *)'} [-Werror=incompatible-pointer-types]
DEBU  2790 |         g_ppm_class->devnode = ppm_devnode;
DEBU       |                              ^
DEBU +cc1: some warnings being treated as errors
DEBU Fmake[2]: *** [scripts/Makefile.build:298: /tmp/driver/main.o] Error 1
DEBU 2make[1]: *** [Makefile:1928: /tmp/driver] Error 2
```
It seems something has changed with the kernel Makefile for these specific kernels where they error with incompatible pointer types in the module build. Seems like a bug upstream maybe?

But to fix it here, we can just inject `-Wno-incompatible-pointer-types` into the `make` command for the kernel Makefile. I figure it should be harmless to have this for other builds that don't require this.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes # N/A

**Special notes for your reviewer**:

Here's it working with the fix on one of the modules:
```
DEBU }+ cd /tmp/driver
DEBU + sed -i 's/make -C $(KERNELDIR)/make KCFLAGS="-Wno-incompatible-pointer-types" -C $(KERNELDIR)/g' Makefile
DEBU 4+ make CC=/usr/bin/gcc-11.0.0 KERNELDIR=/tmp/kernel
DEBU Tmake KCFLAGS="-Wno-incompatible-pointer-types" -C /tmp/kernel M=/tmp/driver modules
DEBU *make[1]: Entering directory '/tmp/kernel'
DEBU   CC [M]  /tmp/driver/main.o
DEBU -  CC [M]  /tmp/driver/dynamic_params_table.o
DEBU &  CC [M]  /tmp/driver/fillers_table.o
DEBU $  CC [M]  /tmp/driver/flags_table.o
DEBU #  CC [M]  /tmp/driver/ppm_events.o
DEBU $  CC [M]  /tmp/driver/ppm_fillers.o
DEBU $  CC [M]  /tmp/driver/event_table.o
DEBU &  CC [M]  /tmp/driver/syscall_table.o
DEBU $  CC [M]  /tmp/driver/ppm_cputime.o
DEBU !  CC [M]  /tmp/driver/tp_table.o
DEBU #  LD [M]  /tmp/driver/scwx-falco.o
DEBU %  MODPOST /tmp/driver/Module.symvers
DEBU '  CC [M]  /tmp/driver/scwx-falco.mod.o
DEBU $  LD [M]  /tmp/driver/scwx-falco.ko
DEBU WSkipping BTF generation for /tmp/driver/scwx-falco.ko due to unavailability of vmlinux
DEBU $  BTF [M] /tmp/driver/scwx-falco.ko
DEBU )make[1]: Leaving directory '/tmp/kernel'
DEBU )+ mv scwx-falco.ko /tmp/driver/module.ko
DEBU !+ strip -g /tmp/driver/module.ko
DEBU  + modinfo /tmp/driver/module.ko
DEBU filename:       /tmp/driver/module.ko
```

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
Add a KCFLAG to the kernel module compile to fix some incompatible pointer types in some CentOS modules
```
