### PR TITLE
cleanup(pkg): cleaned up URLs builder interface method removing config parameter

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -290,6 +290,7 @@ github.com/docker/cli v0.0.0-20191017083524-a8ff7f821017/go.mod h1:JLrzqnKDaYBop
 github.com/docker/distribution v0.0.0-20190905152932-14b96e55d84c/go.mod h1:0+TTO4EOBfRPhZXAeF1Vu+W3hHZ8eLp8PgKVZlcvtFY=
 github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
 github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v1.4.2-0.20190924003213-a8608b5b67c7/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=

--- a/pkg/driverbuilder/builder/aliyunlinux.go
+++ b/pkg/driverbuilder/builder/aliyunlinux.go
@@ -12,8 +12,6 @@ var alinuxTemplate string
 // TargetTypeAlinux identifies the AliyunLinux 2 and 3 target.
 const TargetTypeAlinux Type = "alinux"
 
-
-
 func init() {
 	BuilderByTarget[TargetTypeAlinux] = &alinux{}
 }
@@ -34,7 +32,7 @@ func (c *alinux) TemplateScript() string {
 	return alinuxTemplate
 }
 
-func (c *alinux) URLs(_ Config, kr kernelrelease.KernelRelease) ([]string, error) {
+func (c *alinux) URLs(kr kernelrelease.KernelRelease) ([]string, error) {
 	return fetchAlinuxKernelURLS(kr), nil
 }
 

--- a/pkg/driverbuilder/builder/almalinux.go
+++ b/pkg/driverbuilder/builder/almalinux.go
@@ -33,7 +33,7 @@ func (c *alma) TemplateScript() string {
 	return almaTemplate
 }
 
-func (c *alma) URLs(_ Config, kr kernelrelease.KernelRelease) ([]string, error) {
+func (c *alma) URLs(kr kernelrelease.KernelRelease) ([]string, error) {
 	return fetchAlmaKernelURLS(kr), nil
 }
 
@@ -62,7 +62,7 @@ func fetchAlmaKernelURLS(kr kernelrelease.KernelRelease) []string {
 				kr.Fullversion,
 				kr.FullExtraversion,
 			))
-		}else{
+		} else {
 			urls = append(urls, fmt.Sprintf(
 				"https://repo.almalinux.org/almalinux/%s/BaseOS/%s/os/Packages/kernel-devel-%s%s.rpm",
 				r,

--- a/pkg/driverbuilder/builder/amazonlinux.go
+++ b/pkg/driverbuilder/builder/amazonlinux.go
@@ -78,7 +78,7 @@ func (a *amazonlinux) TemplateScript() string {
 	return amazonlinuxTemplate
 }
 
-func (a *amazonlinux) URLs(_ Config, kr kernelrelease.KernelRelease) ([]string, error) {
+func (a *amazonlinux) URLs(kr kernelrelease.KernelRelease) ([]string, error) {
 	return fetchAmazonLinuxPackagesURLs(a, kr)
 }
 
@@ -114,7 +114,7 @@ func (a *amazonlinux2022) Name() string {
 	return TargetTypeAmazonLinux2022.String()
 }
 
-func (a *amazonlinux2022) URLs(_ Config, kr kernelrelease.KernelRelease) ([]string, error) {
+func (a *amazonlinux2022) URLs(kr kernelrelease.KernelRelease) ([]string, error) {
 	return fetchAmazonLinuxPackagesURLs(a, kr)
 }
 
@@ -137,7 +137,7 @@ func (a *amazonlinux2023) Name() string {
 	return TargetTypeAmazonLinux2023.String()
 }
 
-func (a *amazonlinux2023) URLs(_ Config, kr kernelrelease.KernelRelease) ([]string, error) {
+func (a *amazonlinux2023) URLs(kr kernelrelease.KernelRelease) ([]string, error) {
 	return fetchAmazonLinuxPackagesURLs(a, kr)
 }
 
@@ -159,7 +159,7 @@ func (a *amazonlinux2) Name() string {
 	return TargetTypeAmazonLinux2.String()
 }
 
-func (a *amazonlinux2) URLs(_ Config, kr kernelrelease.KernelRelease) ([]string, error) {
+func (a *amazonlinux2) URLs(kr kernelrelease.KernelRelease) ([]string, error) {
 	return fetchAmazonLinuxPackagesURLs(a, kr)
 }
 

--- a/pkg/driverbuilder/builder/archlinux.go
+++ b/pkg/driverbuilder/builder/archlinux.go
@@ -35,7 +35,7 @@ func (c *archlinux) TemplateScript() string {
 	return archlinuxTemplate
 }
 
-func (c *archlinux) URLs(cfg Config, kr kernelrelease.KernelRelease) ([]string, error) {
+func (c *archlinux) URLs(kr kernelrelease.KernelRelease) ([]string, error) {
 
 	urls := []string{}
 	possibleCompressionSuffixes := []string{

--- a/pkg/driverbuilder/builder/builders.go
+++ b/pkg/driverbuilder/builder/builders.go
@@ -87,10 +87,10 @@ func Script(b Builder, c Config, kr kernelrelease.KernelRelease) (string, error)
 		// Otherwise, it is up to the builder to return an error
 		if len(urls) > 0 {
 			// Check (and filter) existing kernels before continuing
-			urls, err = getResolvingURLs(urls)
+			urls, err = GetResolvingURLs(urls)
 		}
 	} else {
-		urls, err = getResolvingURLs(c.KernelUrls)
+		urls, err = GetResolvingURLs(c.KernelUrls)
 	}
 	if err != nil {
 		return "", err
@@ -269,7 +269,7 @@ func resolveURLReference(u string) string {
 	return base.ResolveReference(uu).String()
 }
 
-func getResolvingURLs(urls []string) ([]string, error) {
+func GetResolvingURLs(urls []string) ([]string, error) {
 	var results []string
 	for _, u := range urls {
 		// in case url has some relative paths

--- a/pkg/driverbuilder/builder/builders.go
+++ b/pkg/driverbuilder/builder/builders.go
@@ -55,7 +55,7 @@ type commonTemplateData struct {
 type Builder interface {
 	Name() string
 	TemplateScript() string
-	URLs(c Config, kr kernelrelease.KernelRelease) ([]string, error)
+	URLs(kr kernelrelease.KernelRelease) ([]string, error)
 	TemplateData(c Config, kr kernelrelease.KernelRelease, urls []string) interface{} // error return type is managed
 }
 
@@ -79,7 +79,7 @@ func Script(b Builder, c Config, kr kernelrelease.KernelRelease) (string, error)
 
 	var urls []string
 	if c.KernelUrls == nil {
-		urls, err = b.URLs(c, kr)
+		urls, err = b.URLs(kr)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/driverbuilder/builder/centos.go
+++ b/pkg/driverbuilder/builder/centos.go
@@ -35,7 +35,7 @@ func (c *centos) TemplateScript() string {
 	return centosTemplate
 }
 
-func (c *centos) URLs(_ Config, kr kernelrelease.KernelRelease) ([]string, error) {
+func (c *centos) URLs(kr kernelrelease.KernelRelease) ([]string, error) {
 	vaultReleases := []string{
 		"6.0/os",
 		"6.0/updates",

--- a/pkg/driverbuilder/builder/debian.go
+++ b/pkg/driverbuilder/builder/debian.go
@@ -45,7 +45,7 @@ func (v *debian) TemplateScript() string {
 	return debianTemplate
 }
 
-func (v *debian) URLs(_ Config, kr kernelrelease.KernelRelease) ([]string, error) {
+func (v *debian) URLs(kr kernelrelease.KernelRelease) ([]string, error) {
 	return fetchDebianKernelURLs(kr)
 }
 

--- a/pkg/driverbuilder/builder/fedora.go
+++ b/pkg/driverbuilder/builder/fedora.go
@@ -35,7 +35,7 @@ func (c *fedora) TemplateScript() string {
 	return fedoraTemplate
 }
 
-func (c *fedora) URLs(_ Config, kr kernelrelease.KernelRelease) ([]string, error) {
+func (c *fedora) URLs(kr kernelrelease.KernelRelease) ([]string, error) {
 
 	// fedora FullExtraversion looks like "-200.fc36.x86_64"
 	// need to get the "fc36" out of the middle

--- a/pkg/driverbuilder/builder/flatcar.go
+++ b/pkg/driverbuilder/builder/flatcar.go
@@ -87,7 +87,7 @@ func fetchFlatcarKernelURLS(kernelVersion string) []string {
 func fetchFlatcarMetadata(kr kernelrelease.KernelRelease) (*flatcarReleaseInfo, error) {
 	flatcarInfo := flatcarReleaseInfo{}
 	flatcarVersion := kr.Fullversion
-	packageIndexUrl, err := getResolvingURLs(fetchFlatcarPackageListURL(kr.Architecture, flatcarVersion))
+	packageIndexUrl, err := GetResolvingURLs(fetchFlatcarPackageListURL(kr.Architecture, flatcarVersion))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/driverbuilder/builder/flatcar.go
+++ b/pkg/driverbuilder/builder/flatcar.go
@@ -38,7 +38,7 @@ func (f *flatcar) TemplateScript() string {
 	return flatcarTemplate
 }
 
-func (f *flatcar) URLs(_ Config, kr kernelrelease.KernelRelease) ([]string, error) {
+func (f *flatcar) URLs(kr kernelrelease.KernelRelease) ([]string, error) {
 	if err := f.fillFlatcarInfos(kr); err != nil {
 		return nil, err
 	}

--- a/pkg/driverbuilder/builder/opensuse.go
+++ b/pkg/driverbuilder/builder/opensuse.go
@@ -85,7 +85,7 @@ func (o *opensuse) URLs(kr kernelrelease.KernelRelease) ([]string, error) {
 	possibleURLs := buildURLs(kr, kernelDefaultDevelPattern, kernelDevelNoArchPattern)
 
 	// trim the list to only resolving URLs
-	urls, err := getResolvingURLs(possibleURLs)
+	urls, err := GetResolvingURLs(possibleURLs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/driverbuilder/builder/opensuse.go
+++ b/pkg/driverbuilder/builder/opensuse.go
@@ -71,7 +71,7 @@ func (o *opensuse) TemplateScript() string {
 	return opensuseTemplate
 }
 
-func (o *opensuse) URLs(_ Config, kr kernelrelease.KernelRelease) ([]string, error) {
+func (o *opensuse) URLs(kr kernelrelease.KernelRelease) ([]string, error) {
 
 	// SUSE requires 2 urls: a kernel-default-devel*{arch}.rpm and a kernel-devel*noarch.rpm
 	kernelDefaultDevelPattern := fmt.Sprintf("kernel-default-devel-%s%s.rpm", kr.Fullversion, kr.FullExtraversion)

--- a/pkg/driverbuilder/builder/oracle.go
+++ b/pkg/driverbuilder/builder/oracle.go
@@ -35,7 +35,7 @@ func (c *oracle) TemplateScript() string {
 	return oracleTemplate
 }
 
-func (c *oracle) URLs(_ Config, kr kernelrelease.KernelRelease) ([]string, error) {
+func (c *oracle) URLs(kr kernelrelease.KernelRelease) ([]string, error) {
 
 	// oracle FullExtraversion looks like "-2047.510.5.5.el7uek.x86_64"
 	// need to get the "el7uek" out of the middle

--- a/pkg/driverbuilder/builder/photon.go
+++ b/pkg/driverbuilder/builder/photon.go
@@ -33,7 +33,7 @@ func (p *photon) TemplateScript() string {
 	return photonTemplate
 }
 
-func (p *photon) URLs(_ Config, kr kernelrelease.KernelRelease) ([]string, error) {
+func (p *photon) URLs(kr kernelrelease.KernelRelease) ([]string, error) {
 	return fetchPhotonKernelURLS(kr), nil
 }
 

--- a/pkg/driverbuilder/builder/redhat.go
+++ b/pkg/driverbuilder/builder/redhat.go
@@ -32,7 +32,7 @@ func (v *redhat) TemplateScript() string {
 	return redhatTemplate
 }
 
-func (v *redhat) URLs(_ Config, _ kernelrelease.KernelRelease) ([]string, error) {
+func (v *redhat) URLs(kr kernelrelease.KernelRelease) ([]string, error) {
 	return nil, nil
 }
 

--- a/pkg/driverbuilder/builder/rocky.go
+++ b/pkg/driverbuilder/builder/rocky.go
@@ -33,7 +33,7 @@ func (c *rocky) TemplateScript() string {
 	return rockyTemplate
 }
 
-func (c *rocky) URLs(_ Config, kr kernelrelease.KernelRelease) ([]string, error) {
+func (c *rocky) URLs(kr kernelrelease.KernelRelease) ([]string, error) {
 	return fetchRockyKernelURLS(kr), nil
 }
 

--- a/pkg/driverbuilder/builder/ubuntu.go
+++ b/pkg/driverbuilder/builder/ubuntu.go
@@ -3,6 +3,7 @@ package builder
 import (
 	_ "embed"
 	"fmt"
+	"github.com/spf13/viper"
 	"regexp"
 	"strings"
 
@@ -41,8 +42,8 @@ func (v *ubuntu) TemplateScript() string {
 	return ubuntuTemplate
 }
 
-func (v *ubuntu) URLs(c Config, kr kernelrelease.KernelRelease) ([]string, error) {
-	return ubuntuHeadersURLFromRelease(kr, c.Build.KernelVersion)
+func (v *ubuntu) URLs(kr kernelrelease.KernelRelease) ([]string, error) {
+	return ubuntuHeadersURLFromRelease(kr, viper.GetString("kernelversion"))
 }
 
 func (v *ubuntu) MinimumURLs() int {
@@ -60,7 +61,7 @@ func (v *ubuntu) TemplateData(c Config, kr kernelrelease.KernelRelease, urls []s
 		headersPattern = "linux-headers*generic"
 	} else {
 		// some flavors (ex: lowlatency-hwe) only contain the first part of the flavor in the directory extracted from the .deb
-		// splitting a flavor without a "-" should just return the original flavor back	
+		// splitting a flavor without a "-" should just return the original flavor back
 		headersPattern = fmt.Sprintf("linux-headers*%s*", strings.Split(flavor, "-")[0])
 	}
 

--- a/pkg/driverbuilder/builder/ubuntu.go
+++ b/pkg/driverbuilder/builder/ubuntu.go
@@ -96,7 +96,7 @@ func ubuntuHeadersURLFromRelease(kr kernelrelease.KernelRelease, kv string) ([]s
 			return nil, err
 		}
 		// try resolving the URLs
-		urls, err := getResolvingURLs(possibleURLs)
+		urls, err := GetResolvingURLs(possibleURLs)
 		// there should be 2 urls returned - the _all.deb package and the _{arch}.deb package
 		if err == nil && len(urls) == ubuntuRequiredURLs {
 			return urls, err

--- a/pkg/driverbuilder/builder/vanilla.go
+++ b/pkg/driverbuilder/builder/vanilla.go
@@ -36,7 +36,7 @@ func (v *vanilla) TemplateScript() string {
 	return vanillaTemplate
 }
 
-func (v *vanilla) URLs(_ Config, kr kernelrelease.KernelRelease) ([]string, error) {
+func (v *vanilla) URLs(kr kernelrelease.KernelRelease) ([]string, error) {
 	return []string{fetchVanillaKernelURLFromKernelVersion(kr)}, nil
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area pkg

**What this PR does / why we need it**:

Reduce `URLs` builder interface method signature avoiding the unused `config` parameter.
It was only used by `ubuntu` builder to fetch build kernelversion; we can use viper for that.
This makes much more practical to use driverkit builder as library in other go projects, because you don't need to instantiate a full driverkit config to fetch URLs; for example:
```Go
var kernelheaders []string
builder, err := builder.Factory(builder.Type(myTarget))
if err != nil {
	logger.Warn(err.Error())
} else {
	kr := kernelrelease.FromString(myKernelRelease)
	kernelheaders, err = builder.URLs(kr)
	if err != nil {
		logger.Warn(err.Error())
	}
        logger.Info("Got headers!", kernelheaders)
}
```

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
