### PR TITLE
chore(cmd): expose ToBuild method.

### DIFF
--- a/cmd/docker.go
+++ b/cmd/docker.go
@@ -16,7 +16,7 @@ func NewDockerCmd(rootOpts *RootOptions, rootFlags *pflag.FlagSet) *cobra.Comman
 		Run: func(c *cobra.Command, args []string) {
 			logger.WithField("processor", c.Name()).Info("driver building, it will take a few seconds")
 			if !configOptions.DryRun {
-				if err := driverbuilder.NewDockerBuildProcessor(viper.GetInt("timeout"), viper.GetString("proxy")).Start(rootOpts.toBuild()); err != nil {
+				if err := driverbuilder.NewDockerBuildProcessor(viper.GetInt("timeout"), viper.GetString("proxy")).Start(rootOpts.ToBuild()); err != nil {
 					logger.WithError(err).Fatal("exiting")
 				}
 			}

--- a/cmd/images.go
+++ b/cmd/images.go
@@ -15,7 +15,7 @@ func NewImagesCmd(rootOpts *RootOptions, rootFlags *pflag.FlagSet) *cobra.Comman
 		Short: "List builder images",
 		Run: func(c *cobra.Command, args []string) {
 			logger.WithField("processor", c.Name()).Info("listing images")
-			b := rootOpts.toBuild()
+			b := rootOpts.ToBuild()
 			b.LoadImages()
 
 			table := tablewriter.NewWriter(os.Stdout)

--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -57,7 +57,7 @@ func NewKubernetesCmd(rootOpts *RootOptions, rootFlags *pflag.FlagSet) *cobra.Co
 
 func kubernetesRun(cmd *cobra.Command, args []string, kubefactory factory.Factory, rootOpts *RootOptions) error {
 	f := cmd.Flags()
-	b := rootOpts.toBuild()
+	b := rootOpts.ToBuild()
 
 	namespaceStr, err := f.GetString("namespace")
 	if err != nil {

--- a/cmd/kubernetes_in_cluster.go
+++ b/cmd/kubernetes_in_cluster.go
@@ -46,7 +46,7 @@ func NewKubernetesInClusterCmd(rootOpts *RootOptions, rootFlags *pflag.FlagSet) 
 }
 
 func kubernetesInClusterRun(_ *cobra.Command, _ []string, kubeConfig *rest.Config, rootOpts *RootOptions) error {
-	b := rootOpts.toBuild()
+	b := rootOpts.ToBuild()
 
 	kc, err := kubernetes.NewForConfig(kubeConfig)
 	if err != nil {

--- a/cmd/root_options.go
+++ b/cmd/root_options.go
@@ -117,7 +117,7 @@ func (ro *RootOptions) Log() {
 	logger.WithFields(fields).Debug("running with options")
 }
 
-func (ro *RootOptions) toBuild() *builder.Build {
+func (ro *RootOptions) ToBuild() *builder.Build {
 	kernelConfigData := ro.KernelConfigData
 	if len(kernelConfigData) == 0 {
 		kernelConfigData = "bm8tZGF0YQ==" // no-data


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area cmd

**What this PR does / why we need it**:

Expose the `ToBuild` method; this allows external applications to run driverkit as library, eg:
```
ro := cmd.RootOptions{...values...}
return driverbuilder.NewDockerBuildProcessor(1000, "").Start(ro.ToBuild())
```

At the moment, clients would have to completely reimplement the `ToBuild` method themselves.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
