### PR TITLE
cleanup(pkg): store kernelversion inside the kernelrelease type.

### DIFF
--- a/pkg/driverbuilder/builder/build.go
+++ b/pkg/driverbuilder/builder/build.go
@@ -54,6 +54,7 @@ type Build struct {
 func (b *Build) KernelReleaseFromBuildConfig() kernelrelease.KernelRelease {
 	kv := kernelrelease.FromString(b.KernelRelease)
 	kv.Architecture = kernelrelease.Architecture(b.Architecture)
+	kv.KernelVersion = b.KernelVersion
 	return kv
 }
 

--- a/pkg/driverbuilder/builder/ubuntu.go
+++ b/pkg/driverbuilder/builder/ubuntu.go
@@ -20,8 +20,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/spf13/viper"
-
 	"github.com/falcosecurity/driverkit/pkg/kernelrelease"
 )
 
@@ -58,7 +56,7 @@ func (v *ubuntu) TemplateScript() string {
 }
 
 func (v *ubuntu) URLs(kr kernelrelease.KernelRelease) ([]string, error) {
-	return ubuntuHeadersURLFromRelease(kr, viper.GetString("kernelversion"))
+	return ubuntuHeadersURLFromRelease(kr)
 }
 
 func (v *ubuntu) MinimumURLs() int {
@@ -88,7 +86,7 @@ func (v *ubuntu) TemplateData(c Config, kr kernelrelease.KernelRelease, urls []s
 	}
 }
 
-func ubuntuHeadersURLFromRelease(kr kernelrelease.KernelRelease, kv string) ([]string, error) {
+func ubuntuHeadersURLFromRelease(kr kernelrelease.KernelRelease) ([]string, error) {
 	// decide which mirrors to use based on the architecture passed in
 	baseURLs := []string{}
 	if kr.Architecture.String() == kernelrelease.ArchitectureAmd64 {
@@ -106,7 +104,7 @@ func ubuntuHeadersURLFromRelease(kr kernelrelease.KernelRelease, kv string) ([]s
 
 	for _, url := range baseURLs {
 		// get all possible URLs
-		possibleURLs, err := fetchUbuntuKernelURL(url, kr, kv)
+		possibleURLs, err := fetchUbuntuKernelURL(url, kr)
 		if err != nil {
 			return nil, err
 		}
@@ -122,7 +120,7 @@ func ubuntuHeadersURLFromRelease(kr kernelrelease.KernelRelease, kv string) ([]s
 	return nil, fmt.Errorf("kernel headers not found")
 }
 
-func fetchUbuntuKernelURL(baseURL string, kr kernelrelease.KernelRelease, kernelVersion string) ([]string, error) {
+func fetchUbuntuKernelURL(baseURL string, kr kernelrelease.KernelRelease) ([]string, error) {
 	// parse the extra number and flavor for the kernelrelease extraversion
 	firstExtra, ubuntuFlavor := parseUbuntuExtraVersion(kr.Extraversion)
 
@@ -156,7 +154,7 @@ func fetchUbuntuKernelURL(baseURL string, kr kernelrelease.KernelRelease, kernel
 			kr.FullExtraversion,
 			kr.Fullversion,
 			firstExtra,
-			kernelVersion,
+			kr.KernelVersion,
 			kr.Architecture.String(),
 		),
 		fmt.Sprintf(
@@ -166,7 +164,7 @@ func fetchUbuntuKernelURL(baseURL string, kr kernelrelease.KernelRelease, kernel
 			ubuntuFlavor,
 			kr.Fullversion,
 			firstExtra,
-			kernelVersion,
+			kr.KernelVersion,
 			kr.Architecture.String(),
 		),
 		fmt.Sprintf(
@@ -176,7 +174,7 @@ func fetchUbuntuKernelURL(baseURL string, kr kernelrelease.KernelRelease, kernel
 			firstExtra,
 			kr.Fullversion,
 			firstExtra,
-			kernelVersion,
+			kr.KernelVersion,
 		),
 		fmt.Sprintf(
 			"linux-headers-%s%s_%s-%s.%s_%s.deb",
@@ -184,7 +182,7 @@ func fetchUbuntuKernelURL(baseURL string, kr kernelrelease.KernelRelease, kernel
 			kr.FullExtraversion,
 			kr.Fullversion,
 			firstExtra,
-			kernelVersion,
+			kr.KernelVersion,
 			kr.Architecture.String(),
 		),
 	}
@@ -197,7 +195,7 @@ func fetchUbuntuKernelURL(baseURL string, kr kernelrelease.KernelRelease, kernel
 				firstExtra,
 				kr.Fullversion,
 				firstExtra,
-				kernelVersion,
+				kr.KernelVersion,
 			))
 	}
 

--- a/pkg/driverbuilder/builder/ubuntu_test.go
+++ b/pkg/driverbuilder/builder/ubuntu_test.go
@@ -24,9 +24,8 @@ import (
 )
 
 var tests = []struct {
-	config        kernelrelease.KernelRelease
-	kernelversion string
-	expected      struct {
+	config   kernelrelease.KernelRelease
+	expected struct {
 		headersURLs []string
 		urls        []string
 		gccVersion  semver.Version
@@ -46,8 +45,8 @@ var tests = []struct {
 			Extraversion:     "188",
 			FullExtraversion: "-188",
 			Architecture:     kernelrelease.ArchitectureAmd64,
+			KernelVersion:    "199",
 		},
-		kernelversion: "199",
 		expected: struct {
 			headersURLs []string
 			urls        []string
@@ -77,8 +76,8 @@ var tests = []struct {
 			Extraversion:     "1140-aws",
 			FullExtraversion: "-1140-aws",
 			Architecture:     kernelrelease.ArchitectureArm64,
+			KernelVersion:    "151",
 		},
-		kernelversion: "151",
 		expected: struct {
 			headersURLs []string
 			urls        []string
@@ -108,8 +107,8 @@ var tests = []struct {
 			Extraversion:     "1004-intel-iotg",
 			FullExtraversion: "-1004-intel-iotg",
 			Architecture:     kernelrelease.ArchitectureAmd64,
+			KernelVersion:    "6",
 		},
-		kernelversion: "6",
 		expected: struct {
 			headersURLs []string
 			urls        []string
@@ -139,8 +138,8 @@ var tests = []struct {
 			Extraversion:     "24-lowlatency-hwe-5.15",
 			FullExtraversion: "-24-lowlatency-hwe-5.15",
 			Architecture:     kernelrelease.ArchitectureAmd64,
+			KernelVersion:    "24~20.04.3",
 		},
-		kernelversion: "24~20.04.3",
 		expected: struct {
 			headersURLs []string
 			urls        []string
@@ -170,8 +169,8 @@ var tests = []struct {
 			Extraversion:     "9",
 			FullExtraversion: "-9",
 			Architecture:     kernelrelease.ArchitectureAmd64,
+			KernelVersion:    "9",
 		},
-		kernelversion: "9",
 		expected: struct {
 			headersURLs []string
 			urls        []string
@@ -221,8 +220,8 @@ var tests = []struct {
 			Extraversion:     "38-lts-utopic",
 			FullExtraversion: "-38-lts-utopic",
 			Architecture:     kernelrelease.ArchitectureAmd64,
+			KernelVersion:    "52~14.04.1",
 		},
-		kernelversion: "52~14.04.1",
 		expected: struct {
 			headersURLs []string
 			urls        []string
@@ -252,8 +251,8 @@ var tests = []struct {
 			Extraversion:     "1006-kvm",
 			FullExtraversion: "-1006-kvm",
 			Architecture:     kernelrelease.ArchitectureAmd64,
+			KernelVersion:    "6",
 		},
-		kernelversion: "6",
 		expected: struct {
 			headersURLs []string
 			urls        []string
@@ -278,33 +277,24 @@ func TestUbuntuHeadersURLFromRelease(t *testing.T) {
 	for _, test := range tests {
 		expected := test.expected.headersURLs
 
-		// setup input
-		input := struct {
-			config kernelrelease.KernelRelease
-			kv     string
-		}{
-			test.config,
-			test.kernelversion,
-		}
-
 		// call function
-		gotURLs, err := ubuntuHeadersURLFromRelease(input.config, input.kv)
+		gotURLs, err := ubuntuHeadersURLFromRelease(test.config)
 		// compare errors
 		// there are no official errors, so comparing fmt.Errorf() doesn't really work
 		// compare error message text instead
 		if err != nil && test.expected.err != nil && err.Error() != test.expected.err.Error() {
-			t.Fatalf("Unexpected error encountered with Test Input: '%v' | Error: '%s'", input, err)
+			t.Fatalf("Unexpected error encountered with Test Input: '%v' | Error: '%s'", test.config, err)
 		}
 
 		// check length of URL slice returned
 		if len(gotURLs) != len(expected) {
-			t.Fatalf("Slice sizes don't match! Test Input: '%v' | Got: '%v' / Want: '%v'", input, gotURLs, expected)
+			t.Fatalf("Slice sizes don't match! Test Input: '%v' | Got: '%v' / Want: '%v'", test.config, gotURLs, expected)
 		}
 
 		// check values are exact match
 		for i, v := range gotURLs {
 			if v != expected[i] {
-				t.Fatalf("Slice values don't match! Test Input: '%v' | Got: '%v' / Want: '%v'", input, gotURLs, expected)
+				t.Fatalf("Slice values don't match! Test Input: '%v' | Got: '%v' / Want: '%v'", test.config, gotURLs, expected)
 			}
 		}
 	}
@@ -332,15 +322,13 @@ func TestFetchUbuntuKernelURL(t *testing.T) {
 			input := struct {
 				baseURL string
 				config  kernelrelease.KernelRelease
-				kv      string
 			}{
 				url,
 				test.config,
-				test.kernelversion,
 			}
 
 			// call function
-			gotURLs, err := fetchUbuntuKernelURL(input.baseURL, input.config, input.kv)
+			gotURLs, err := fetchUbuntuKernelURL(input.baseURL, input.config)
 			if err != nil {
 				t.Fatalf("Unexpected error encountered with Test Input: '%v' | Error: '%s'", input, err)
 			}

--- a/pkg/kernelrelease/kernelrelease.go
+++ b/pkg/kernelrelease/kernelrelease.go
@@ -146,3 +146,7 @@ func (k *KernelRelease) SupportsModule() bool {
 func (k *KernelRelease) SupportsProbe() bool {
 	return k.GTE(probeMinKernelVersion[k.Architecture])
 }
+
+func (k *KernelRelease) String() string {
+	return fmt.Sprintf("%s%s", k.Fullversion, k.FullExtraversion)
+}

--- a/pkg/kernelrelease/kernelrelease.go
+++ b/pkg/kernelrelease/kernelrelease.go
@@ -102,6 +102,7 @@ type KernelRelease struct {
 	Extraversion     string
 	FullExtraversion string
 	Architecture     Architecture
+	KernelVersion    string
 }
 
 // FromString extracts a KernelRelease object from string.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area pkg

**What this PR does / why we need it**:

Since it is only used by ubuntu, avoid directly calling `viper.GetString()`.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
