### PR TITLE
SUSE Linux Enterprise Support

### DIFF
--- a/pkg/driverbuilder/builder/sle.go
+++ b/pkg/driverbuilder/builder/sle.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2023 The Falco Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builder
+
+import (
+	_ "embed"
+
+	"github.com/falcosecurity/driverkit/pkg/kernelrelease"
+)
+
+//go:embed templates/sle.sh
+var sleTemplate string
+
+// TargetTypeSLE identifies the sle target.
+const TargetTypeSLE Type = "sle"
+
+// sle is a driverkit target.
+type sle struct {
+}
+
+func init() {
+	byTarget[TargetTypeSLE] = &sle{}
+}
+
+type sleTemplateData struct {
+	commonTemplateData
+	KernelPackage string
+}
+
+func (v *sle) Name() string {
+	return TargetTypeSLE.String()
+}
+
+func (v *sle) TemplateScript() string {
+	return sleTemplate
+}
+
+func (v *sle) URLs(kr kernelrelease.KernelRelease) ([]string, error) {
+	return nil, nil
+}
+
+func (v *sle) MinimumURLs() int {
+	// We don't need any url
+	return 0
+}
+
+func (v *sle) TemplateData(c Config, kr kernelrelease.KernelRelease, _ []string) interface{} {
+	return sleTemplateData{
+		commonTemplateData: c.toTemplateData(v, kr),
+		KernelPackage:      kr.Fullversion + kr.FullExtraversion,
+	}
+}

--- a/pkg/driverbuilder/builder/templates/sle.sh
+++ b/pkg/driverbuilder/builder/templates/sle.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (C) 2023 The Falco Authors.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Simple script that desperately tries to load the kernel instrumentation by
+# looking for it in a bunch of ways. Convenient when running Falco inside
+# a container or in other weird environments.
+#
+set -xeuo pipefail
+
+rm -Rf {{ .DriverBuildDir }}
+mkdir {{ .DriverBuildDir }}
+rm -Rf /tmp/module-download
+mkdir -p /tmp/module-download
+
+curl --silent -SL {{ .ModuleDownloadURL }} | tar -xzf - -C /tmp/module-download
+mv /tmp/module-download/*/driver/* {{ .DriverBuildDir }}
+
+cp /driverkit/module-Makefile {{ .DriverBuildDir }}/Makefile
+bash /driverkit/fill-driver-config.sh {{ .DriverBuildDir }}
+
+# Fetch the kernel
+rm -Rf /tmp/kernel-download
+mkdir /tmp/kernel-download
+cd /tmp/kernel-download
+zypper install --non-interactive --download-only --downloaddir=/tmp/kernel-download kernel-devel={{ .KernelPackage }}
+rpm2cpio kernel-devel-{{ .KernelPackage }}.rpm | cpio --extract --make-directories
+
+rm -Rf /tmp/kernel
+mkdir -p /tmp/kernel
+mv usr/src/kernels/*/* /tmp/kernel
+
+{{ if .BuildModule }}
+# Build the module
+cd {{ .DriverBuildDir }}
+make CC=/usr/bin/gcc-{{ .GCCVersion }} KERNELDIR=/tmp/kernel
+mv {{ .ModuleDriverName }}.ko {{ .ModuleFullPath }}
+strip -g {{ .ModuleFullPath }}
+# Print results
+modinfo {{ .ModuleFullPath }}
+{{ end }}
+
+{{ if .BuildProbe }}
+# Build the eBPF probe
+cd {{ .DriverBuildDir }}/bpf
+make KERNELDIR=/tmp/kernel
+ls -l probe.o
+{{ end }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area cmd

> /area pkg

> /area docs

> /area tests


**What this PR does / why we need it**:

Adds initial support for SUSE Linux Enterprise. It's much like RHEL, will require a `--builderimage` with authentication setup, but it does allow the user the ability to bring-your-own-container and build.

Example:
```
scwx-sles12-sp5:~/driverkit # ~/driverkit/_output/bin/driverkit docker --kernelrelease 4.12.14-122.7.1 --kernelversion 1 --target sle --output-module ./test.ko --builderimage sle-builder:latest
level=INFO msg="driver building, it will take a few seconds" processor=docker
level=INFO msg="kernel module available" path=./test.ko
```

An example of a hacked-together Dockerfile used for the above build:
```
FROM registry.suse.com/suse/sles12sp5

COPY credentials/* /etc/zypp/credentials.d/

RUN zypper ref -s && zypper install -y SUSEConnect && SUSEConnect -p sle-module-toolchain/12/x86_64

RUN zypper ref && zypper --non-interactive install \
	make  \
	gcc   \
	tar   \
	gzip  \
	curl  \
	gcc8  \
	kmod && \
    ln -s /usr/bin/gcc-8 /usr/bin/gcc-8.0.0
```

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes # N/A

**Special notes for your reviewer**:

Crawling for SLES/D kernels should be relatively easy as well, using the same sort of strategy as RHEL with an authenticated container. I'll be making a PR to kernel-crawler as well.

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
Adds SUSE Linux Enterprise support
```
