### PR TITLE
cleanup(cmd): require kernelrelease and kernelversion in local command.

### DIFF
--- a/cmd/local.go
+++ b/cmd/local.go
@@ -1,17 +1,14 @@
 package cmd
 
 import (
-	"bytes"
 	"github.com/falcosecurity/driverkit/pkg/driverbuilder"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-	"golang.org/x/sys/unix"
 	"log/slog"
 	"os"
 	"os/user"
 	"runtime"
-	"strings"
 )
 
 type localCmdOptions struct {
@@ -55,8 +52,6 @@ func NewLocalCmd(rootCommand *RootCmd, rootOpts *RootOptions, rootFlags *pflag.F
 	// Add root flags, but not the ones unneeded
 	unusedFlagsSet := map[string]struct{}{
 		"architecture":        {},
-		"kernelrelease":       {},
-		"kernelversion":       {},
 		"target":              {},
 		"kernelurls":          {},
 		"builderrepo":         {},
@@ -87,19 +82,6 @@ func persistentPreRunFunc(rootCommand *RootCmd, rootOpts *RootOptions) func(c *c
 	return func(c *cobra.Command, args []string) error {
 		// Default values
 		rootOpts.Target = "local"
-		u := unix.Utsname{}
-		if err := unix.Uname(&u); err != nil {
-			slog.Error("failed to retrieve default uname values", "err", err)
-			// this only affects logs!
-			rootOpts.KernelRelease = "1.0.0"
-			rootOpts.KernelVersion = "1"
-		} else {
-			rootOpts.KernelRelease = string(bytes.Trim(u.Release[:], "\x00"))
-			kv := string(bytes.Trim(u.Version[:], "\x00"))
-			kv = strings.Trim(kv, "#")
-			kv = strings.Split(kv, " ")[0]
-			rootOpts.KernelVersion = kv
-		}
 		rootOpts.Architecture = runtime.GOARCH
 		return rootCommand.c.PersistentPreRunE(c, args)
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area cmd

**What this PR does / why we need it**:

Require `kernelrelease` and eventually `kernelversion` to be passed by user instead of using `unix`. This allows driverkit to be portable (eg: building on windows).
Useful to fix https://github.com/falcosecurity/falcoctl/pull/356 since falcoctl is built for windows and osx too and its deps must be portable.

It is a small UX worsening but since all driverkit commands already require `kernelrelease`, i think it is safe to do so for `local` too.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
