### PR TITLE
chore: fixed manifest creation and push.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,15 +87,12 @@ manifest/all: manifest/driverkit
 
 .PHONY: manifest/driverkit
 manifest/driverkit:
-	$(DOCKER) manifest create $(IMAGE_NAME_DRIVERKIT):$(GIT_REF) $(IMAGE_NAME_DRIVERKIT):$(GIT_REF)_x86_64 $(IMAGE_NAME_DRIVERKIT):$(GIT_REF)_aarch64
-	$(DOCKER) manifest push $(IMAGE_NAME_DRIVERKIT):$(GIT_REF)
-	$(DOCKER) manifest create $(IMAGE_NAME_DRIVERKIT):$(GIT_COMMIT) $(IMAGE_NAME_DRIVERKIT):$(GIT_COMMIT)_x86_64 $(IMAGE_NAME_DRIVERKIT):$(GIT_COMMIT)_aarch64
-	$(DOCKER) manifest push $(IMAGE_NAME_DRIVERKIT):$(GIT_COMMIT)
+	$(DOCKER) buildx imagetools create -t $(IMAGE_NAME_DRIVERKIT):$(GIT_REF) $(IMAGE_NAME_DRIVERKIT):$(GIT_REF)_x86_64 $(IMAGE_NAME_DRIVERKIT):$(GIT_REF)_aarch64
+	$(DOCKER) buildx imagetools create -t $(IMAGE_NAME_DRIVERKIT):$(GIT_COMMIT) $(IMAGE_NAME_DRIVERKIT):$(GIT_COMMIT)_x86_64 $(IMAGE_NAME_DRIVERKIT):$(GIT_COMMIT)_aarch64
 
 .PHONY: manifest/latest
 manifest/latest:
-	$(DOCKER) manifest create $(IMAGE_NAME_DRIVERKIT):latest $(IMAGE_NAME_DRIVERKIT):latest_x86_64 $(IMAGE_NAME_DRIVERKIT):latest_aarch64
-	$(DOCKER) manifest push $(IMAGE_NAME_DRIVERKIT):latest
+	$(DOCKER) buildx imagetools create -t $(IMAGE_NAME_DRIVERKIT):latest $(IMAGE_NAME_DRIVERKIT):latest_x86_64 $(IMAGE_NAME_DRIVERKIT):latest_aarch64
 
 .PHONY: test
 test:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

Follows https://stackoverflow.com/questions/75521775/buildx-docker-image-claims-to-be-a-manifest-list and fixes currently broken `manifest` related CI.
Also, this is what is done by [`docker-manifest-create-action`](https://github.com/int128/docker-manifest-create-action/tree/main).

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
