### PR TITLE
new: glibc 2.38 builder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,9 @@ jobs:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+        uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
-          check-latest: true
+          go-version-file: 'go.mod'
 
       - name: Execute go mod tidy and check the outcome
         working-directory: ./

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,9 +51,9 @@ jobs:
         run: git fetch --prune --force --tags
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version-file: 'go.mod'
       
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/reusable_build_test_driverkit.yml
+++ b/.github/workflows/reusable_build_test_driverkit.yml
@@ -18,9 +18,9 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version-file: 'go.mod'
 
       - name: Build
         run: make build

--- a/docker/builders/builder-any-aarch64_gcc13.0.0.Dockerfile
+++ b/docker/builders/builder-any-aarch64_gcc13.0.0.Dockerfile
@@ -1,0 +1,1 @@
+builder-any-x86_64_gcc13.0.0.Dockerfile

--- a/docker/builders/builder-any-x86_64_gcc13.0.0.Dockerfile
+++ b/docker/builders/builder-any-x86_64_gcc13.0.0.Dockerfile
@@ -1,0 +1,40 @@
+FROM fedora:39
+
+LABEL maintainer="cncf-falco-dev@lists.cncf.io"
+
+ARG TARGETARCH
+
+RUN dnf install -y \
+	bash-completion \
+	bc \
+	clang \
+	llvm \
+	ca-certificates \
+	curl \
+	dkms \
+	dwarves \
+	gnupg2 \
+	gcc \
+	jq \
+	glibc-devel \
+	elfutils-libelf-devel \
+	netcat \
+	xz \
+	cpio \
+	flex \
+	bison \
+	openssl \
+	openssl-devel \
+	ncurses-devel \
+	systemd-devel \
+	pciutils-devel \
+	binutils-devel \
+	lsb-release \
+	wget \
+	gpg \
+	zstd \
+	cmake \
+	git
+
+# Properly create soft links
+RUN ln -s /usr/bin/gcc /usr/bin/gcc-13.0.0

--- a/pkg/driverbuilder/builder/builders.go
+++ b/pkg/driverbuilder/builder/builders.go
@@ -135,6 +135,11 @@ type GCCVersionRequestor interface {
 
 func defaultGCC(kr kernelrelease.KernelRelease) semver.Version {
 	switch kr.Major {
+	case 6:
+		if kr.Minor >= 6 {
+			return semver.Version{Major: 13}
+		}
+		return semver.Version{Major: 12}
 	case 5:
 		if kr.Minor >= 15 {
 			return semver.Version{Major: 12}
@@ -150,7 +155,7 @@ func defaultGCC(kr kernelrelease.KernelRelease) semver.Version {
 	case 2:
 		return semver.Version{Major: 4, Minor: 8}
 	default:
-		return semver.Version{Major: 12}
+		return semver.Version{Major: 13}
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area build
/area pkg

**What this PR does / why we need it**:

This PR introduces a new fedora based `any` builder to be able to build recent kernels (6.6+)  that require glibc 2.38.

**Which issue(s) this PR fixes**:

Fixes #303 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
new: added a new glibc 2.38 gcc 13 based builder image.
```
