### PR TITLE
fix(pkg/driverbuilder): fixed local cmd build up using os.Environ().

### DIFF
--- a/pkg/driverbuilder/builder/templates/local.sh
+++ b/pkg/driverbuilder/builder/templates/local.sh
@@ -59,6 +59,12 @@ modinfo {{ .ModuleFullPath }}
 
 {{ if .BuildProbe }}
 echo "* Building eBPF probe"
+
+if [ ! -d /sys/kernel/debug/tracing ]; then
+  echo "* Mounting debugfs"
+  mount -t debugfs nodev /sys/kernel/debug
+fi
+
 # Build the eBPF probe
 cd {{ .DriverBuildDir }}/bpf
 make

--- a/pkg/driverbuilder/local.go
+++ b/pkg/driverbuilder/local.go
@@ -128,6 +128,7 @@ func (lbp *LocalBuildProcessor) Start(b *builder.Build) error {
 		ctx, cancelFunc := context.WithTimeout(context.Background(), time.Duration(lbp.timeout)*time.Second)
 		defer cancelFunc()
 		cmd := exec.CommandContext(ctx, "/bin/bash", "-c", driverkitScript)
+		cmd.Env = os.Environ()
 		// Append requested env variables to the command env
 		for key, val := range lbp.envMap {
 			cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, val))


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area pkg

**What this PR does / why we need it**:

Moreover, properly mount debugfs before attempting the bpf probe build if needed.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
