### PR TITLE
cleanup: no verbose tar and avoid ls

### DIFF
--- a/pkg/driverbuilder/builder/templates/debian.sh
+++ b/pkg/driverbuilder/builder/templates/debian.sh
@@ -36,7 +36,7 @@ cd /tmp/kernel-download
 {{ range $url := .KernelDownloadURLS }}
 curl --silent -o kernel.deb -SL {{ $url }}
 ar x kernel.deb
-tar -xvf data.tar.xz
+tar -xf data.tar.xz
 {{ end }}
 
 cd /tmp/kernel-download/

--- a/pkg/driverbuilder/builder/templates/opensuse.sh
+++ b/pkg/driverbuilder/builder/templates/opensuse.sh
@@ -39,7 +39,6 @@ curl --silent -o kernel-devel.rpm -SL {{ $url }}
 rpm2cpio kernel-devel.rpm | cpio --quiet --extract --make-directories 2> /dev/null
 {{end}}
 cd /tmp/kernel-download/usr/src
-ls -alh /tmp/kernel-download/usr/src
 sourcedir="$(find . -type d -name "linux-*-obj" | head -n 1 | xargs readlink -f)/*/default"
 
 cd {{ .DriverBuildDir }}

--- a/pkg/driverbuilder/builder/templates/sles.sh
+++ b/pkg/driverbuilder/builder/templates/sles.sh
@@ -41,7 +41,6 @@ do
     rpm2cpio $rpm | cpio --extract --make-directories
 done
 
-ls -alh /tmp/kernel-download/usr/src
 sourcedir="$(find . -type d -name "linux-*-obj" | head -n 1 | xargs readlink -f)/*/default"
 
 cd {{ .DriverBuildDir }}

--- a/pkg/driverbuilder/builder/templates/ubuntu.sh
+++ b/pkg/driverbuilder/builder/templates/ubuntu.sh
@@ -40,7 +40,6 @@ tar -xf data.tar.*
 {{end}}
 
 cd /tmp/kernel-download/usr/src/
-ls -altr
 sourcedir=$(find . -type d -name "{{ .KernelHeadersPattern }}" | head -n 1 | xargs readlink -f)
 
 cd {{ .DriverBuildDir }}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area pkg

**What this PR does / why we need it**:

This PR makes build templates less verbose by dropping a `tar` `-v` flag and some debug `ls`.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
