### PR TITLE
new(pkg,cmd): refactored builder script logic.

### DIFF
--- a/cmd/local.go
+++ b/cmd/local.go
@@ -72,7 +72,7 @@ func NewLocalCmd(rootCommand *RootCmd, rootOpts *RootOptions, rootFlags *pflag.F
 	})
 	flagSet.BoolVar(&opts.useDKMS, "dkms", false, "Enforce usage of DKMS to build the kernel module.")
 	flagSet.StringVar(&opts.srcDir, "src-dir", "", "Enforce usage of local source dir to build drivers.")
-	flagSet.StringToStringVar(&opts.envMap, "env", nil, "Env variables to be enforced during the driver build.")
+	flagSet.StringToStringVar(&opts.envMap, "env", make(map[string]string), "Env variables to be enforced during the driver build.")
 	localCmd.PersistentFlags().AddFlagSet(flagSet)
 	return localCmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -184,7 +184,7 @@ func NewRootCmd() *RootCmd {
 	rootCmd.AddCommand(NewKubernetesCmd(rootOpts, flags))
 	rootCmd.AddCommand(NewKubernetesInClusterCmd(rootOpts, flags))
 	rootCmd.AddCommand(NewDockerCmd(rootOpts, flags))
-	rootCmd.AddCommand(NewLocalCmd(ret, rootOpts, flags))
+	rootCmd.AddCommand(NewLocalCmd(rootOpts, flags))
 	rootCmd.AddCommand(NewImagesCmd(rootOpts, flags))
 	rootCmd.AddCommand(NewCompletionCmd())
 

--- a/pkg/driverbuilder/builder/aliyunlinux.go
+++ b/pkg/driverbuilder/builder/aliyunlinux.go
@@ -21,6 +21,9 @@ import (
 	"github.com/falcosecurity/driverkit/pkg/kernelrelease"
 )
 
+//go:embed templates/alinux_kernel.sh
+var alinuxKernelTemplate string
+
 //go:embed templates/alinux.sh
 var alinuxTemplate string
 
@@ -32,7 +35,6 @@ func init() {
 }
 
 type alinuxTemplateData struct {
-	commonTemplateData
 	KernelDownloadURL string
 }
 
@@ -43,6 +45,10 @@ func (c *alinux) Name() string {
 	return TargetTypeAlinux.String()
 }
 
+func (c *alinux) TemplateKernelUrlsScript() string {
+	return alinuxKernelTemplate
+}
+
 func (c *alinux) TemplateScript() string {
 	return alinuxTemplate
 }
@@ -51,10 +57,9 @@ func (c *alinux) URLs(kr kernelrelease.KernelRelease) ([]string, error) {
 	return fetchAlinuxKernelURLS(kr), nil
 }
 
-func (c *alinux) TemplateData(cfg Config, kr kernelrelease.KernelRelease, urls []string) interface{} {
+func (c *alinux) KernelTemplateData(_ kernelrelease.KernelRelease, urls []string) interface{} {
 	return alinuxTemplateData{
-		commonTemplateData: cfg.toTemplateData(c, kr),
-		KernelDownloadURL:  urls[0],
+		KernelDownloadURL: urls[0],
 	}
 }
 

--- a/pkg/driverbuilder/builder/almalinux.go
+++ b/pkg/driverbuilder/builder/almalinux.go
@@ -21,6 +21,9 @@ import (
 	"github.com/falcosecurity/driverkit/pkg/kernelrelease"
 )
 
+//go:embed templates/almalinux_kernel.sh
+var almaKernelTemplate string
+
 //go:embed templates/almalinux.sh
 var almaTemplate string
 
@@ -32,7 +35,6 @@ func init() {
 }
 
 type almaTemplateData struct {
-	commonTemplateData
 	KernelDownloadURL string
 }
 
@@ -44,6 +46,10 @@ func (c *alma) Name() string {
 	return TargetTypeAlma.String()
 }
 
+func (c *alma) TemplateKernelUrlsScript() string {
+	return almaKernelTemplate
+}
+
 func (c *alma) TemplateScript() string {
 	return almaTemplate
 }
@@ -52,10 +58,9 @@ func (c *alma) URLs(kr kernelrelease.KernelRelease) ([]string, error) {
 	return fetchAlmaKernelURLS(kr), nil
 }
 
-func (c *alma) TemplateData(cfg Config, kr kernelrelease.KernelRelease, urls []string) interface{} {
+func (c *alma) KernelTemplateData(_ kernelrelease.KernelRelease, urls []string) interface{} {
 	return almaTemplateData{
-		commonTemplateData: cfg.toTemplateData(c, kr),
-		KernelDownloadURL:  urls[0],
+		KernelDownloadURL: urls[0],
 	}
 }
 

--- a/pkg/driverbuilder/builder/amazonlinux.go
+++ b/pkg/driverbuilder/builder/amazonlinux.go
@@ -35,6 +35,9 @@ import (
 	"github.com/falcosecurity/driverkit/pkg/kernelrelease"
 )
 
+//go:embed templates/amazonlinux_kernel.sh
+var amazonlinuxKernelTemplate string
+
 //go:embed templates/amazonlinux.sh
 var amazonlinuxTemplate string
 
@@ -80,13 +83,14 @@ func init() {
 }
 
 type amazonlinuxTemplateData struct {
-	commonTemplateData
 	KernelDownloadURLs []string
 }
 
 func (a *amazonlinux) Name() string {
 	return TargetTypeAmazonLinux.String()
 }
+
+func (a *amazonlinux) TemplateKernelUrlsScript() string { return amazonlinuxKernelTemplate }
 
 func (a *amazonlinux) TemplateScript() string {
 	return amazonlinuxTemplate
@@ -96,9 +100,8 @@ func (a *amazonlinux) URLs(kr kernelrelease.KernelRelease) ([]string, error) {
 	return fetchAmazonLinuxPackagesURLs(a, kr)
 }
 
-func (a *amazonlinux) TemplateData(c Config, kr kernelrelease.KernelRelease, urls []string) interface{} {
+func (a *amazonlinux) KernelTemplateData(_ kernelrelease.KernelRelease, urls []string) interface{} {
 	return amazonlinuxTemplateData{
-		commonTemplateData: c.toTemplateData(a, kr),
 		KernelDownloadURLs: urls,
 	}
 }

--- a/pkg/driverbuilder/builder/archlinux.go
+++ b/pkg/driverbuilder/builder/archlinux.go
@@ -22,6 +22,9 @@ import (
 	"github.com/falcosecurity/driverkit/pkg/kernelrelease"
 )
 
+//go:embed templates/archlinux_kernel.sh
+var archlinuxKernelTemplate string
+
 //go:embed templates/archlinux.sh
 var archlinuxTemplate string
 
@@ -37,13 +40,14 @@ type archlinux struct {
 }
 
 type archlinuxTemplateData struct {
-	commonTemplateData
 	KernelDownloadURL string
 }
 
 func (c *archlinux) Name() string {
 	return TargetTypeArchlinux.String()
 }
+
+func (c *archlinux) TemplateKernelUrlsScript() string { return archlinuxKernelTemplate }
 
 func (c *archlinux) TemplateScript() string {
 	return archlinuxTemplate
@@ -140,9 +144,8 @@ func (c *archlinux) URLs(kr kernelrelease.KernelRelease) ([]string, error) {
 	return urls, nil
 }
 
-func (c *archlinux) TemplateData(cfg Config, kr kernelrelease.KernelRelease, urls []string) interface{} {
+func (c *archlinux) KernelTemplateData(_ kernelrelease.KernelRelease, urls []string) interface{} {
 	return archlinuxTemplateData{
-		commonTemplateData: cfg.toTemplateData(c, kr),
-		KernelDownloadURL:  urls[0],
+		KernelDownloadURL: urls[0],
 	}
 }

--- a/pkg/driverbuilder/builder/archlinux.go
+++ b/pkg/driverbuilder/builder/archlinux.go
@@ -54,6 +54,12 @@ func (c *archlinux) TemplateScript() string {
 }
 
 func (c *archlinux) URLs(kr kernelrelease.KernelRelease) ([]string, error) {
+	// uname -r returns "6.8.1-arch1-1" but headers URL is "6.8.1.arch1-1"
+	// Also, for 0-patch releases, like: "6.8.0-arch1-1", headers url is "6.8.arch1-1"
+	kr.FullExtraversion = strings.Replace(kr.FullExtraversion, "-arch", ".arch", 1)
+	if kr.Patch == 0 {
+		kr.Fullversion = strings.TrimSuffix(kr.Fullversion, ".0")
+	}
 
 	urls := []string{}
 	possibleCompressionSuffixes := []string{

--- a/pkg/driverbuilder/builder/bottlerocket.go
+++ b/pkg/driverbuilder/builder/bottlerocket.go
@@ -35,9 +35,8 @@ func (b *bottlerocket) Name() string {
 	return TargetTypeBottlerocket.String()
 }
 
-func (b *bottlerocket) TemplateData(c Config, kr kernelrelease.KernelRelease, urls []string) interface{} {
+func (b *bottlerocket) KernelTemplateData(kr kernelrelease.KernelRelease, urls []string) interface{} {
 	return vanillaTemplateData{
-		commonTemplateData: c.toTemplateData(b, kr),
 		KernelDownloadURL:  urls[0],
 		KernelLocalVersion: kr.FullExtraversion,
 	}

--- a/pkg/driverbuilder/builder/builders.go
+++ b/pkg/driverbuilder/builder/builders.go
@@ -132,7 +132,7 @@ func LibsDownloadScript(c Config) (string, error) {
 }
 
 // KernelDownloadScript returns the script that will download and extract kernel headers
-func KernelDownloadScript(b Builder, c Config, kr kernelrelease.KernelRelease) (string, error) {
+func KernelDownloadScript(b Builder, kernelurls []string, kr kernelrelease.KernelRelease) (string, error) {
 	t := template.New("download-kernel")
 	parsed, err := t.Parse(b.TemplateKernelUrlsScript())
 	if err != nil {
@@ -145,7 +145,7 @@ func KernelDownloadScript(b Builder, c Config, kr kernelrelease.KernelRelease) (
 		minimumURLs = bb.MinimumURLs()
 	}
 
-	if c.KernelUrls == nil {
+	if kernelurls == nil {
 		urls, err = b.URLs(kr)
 		if err != nil {
 			return "", err
@@ -157,7 +157,7 @@ func KernelDownloadScript(b Builder, c Config, kr kernelrelease.KernelRelease) (
 			urls, err = GetResolvingURLs(urls)
 		}
 	} else {
-		urls, err = GetResolvingURLs(c.KernelUrls)
+		urls, err = GetResolvingURLs(kernelurls)
 	}
 	if err != nil {
 		return "", err

--- a/pkg/driverbuilder/builder/centos.go
+++ b/pkg/driverbuilder/builder/centos.go
@@ -22,6 +22,9 @@ import (
 	"github.com/falcosecurity/driverkit/pkg/kernelrelease"
 )
 
+//go:embed templates/centos_kernel.sh
+var centosKernelTemplate string
+
 //go:embed templates/centos.sh
 var centosTemplate string
 
@@ -37,13 +40,14 @@ type centos struct {
 }
 
 type centosTemplateData struct {
-	commonTemplateData
 	KernelDownloadURL string
 }
 
 func (c *centos) Name() string {
 	return TargetTypeCentos.String()
 }
+
+func (c *centos) TemplateKernelUrlsScript() string { return centosKernelTemplate }
 
 func (c *centos) TemplateScript() string {
 	return centosTemplate
@@ -176,10 +180,9 @@ func (c *centos) URLs(kr kernelrelease.KernelRelease) ([]string, error) {
 	return urls, nil
 }
 
-func (c *centos) TemplateData(cfg Config, kr kernelrelease.KernelRelease, urls []string) interface{} {
+func (c *centos) KernelTemplateData(_ kernelrelease.KernelRelease, urls []string) interface{} {
 	return centosTemplateData{
-		commonTemplateData: cfg.toTemplateData(c, kr),
-		KernelDownloadURL:  urls[0],
+		KernelDownloadURL: urls[0],
 	}
 }
 

--- a/pkg/driverbuilder/builder/debian.go
+++ b/pkg/driverbuilder/builder/debian.go
@@ -25,6 +25,9 @@ import (
 	"github.com/falcosecurity/driverkit/pkg/kernelrelease"
 )
 
+//go:embed templates/debian_kernel.sh
+var debianKernelTemplate string
+
 //go:embed templates/debian.sh
 var debianTemplate string
 
@@ -42,7 +45,6 @@ func init() {
 }
 
 type debianTemplateData struct {
-	commonTemplateData
 	KernelDownloadURLS   []string
 	KernelLocalVersion   string
 	KernelHeadersPattern string
@@ -56,6 +58,8 @@ func (v *debian) Name() string {
 	return TargetTypeDebian.String()
 }
 
+func (v *debian) TemplateKernelUrlsScript() string { return debianKernelTemplate }
+
 func (v *debian) TemplateScript() string {
 	return debianTemplate
 }
@@ -64,7 +68,7 @@ func (v *debian) URLs(kr kernelrelease.KernelRelease) ([]string, error) {
 	return fetchDebianKernelURLs(kr)
 }
 
-func (v *debian) TemplateData(c Config, kr kernelrelease.KernelRelease, urls []string) interface{} {
+func (v *debian) KernelTemplateData(kr kernelrelease.KernelRelease, urls []string) interface{} {
 	var KernelHeadersPattern string
 	if strings.HasSuffix(kr.Extraversion, "pve") {
 		KernelHeadersPattern = "linux-headers-*pve"
@@ -75,7 +79,6 @@ func (v *debian) TemplateData(c Config, kr kernelrelease.KernelRelease, urls []s
 	}
 
 	return debianTemplateData{
-		commonTemplateData:   c.toTemplateData(v, kr),
 		KernelDownloadURLS:   urls,
 		KernelLocalVersion:   kr.FullExtraversion,
 		KernelHeadersPattern: KernelHeadersPattern,

--- a/pkg/driverbuilder/builder/fedora.go
+++ b/pkg/driverbuilder/builder/fedora.go
@@ -22,6 +22,9 @@ import (
 	"github.com/falcosecurity/driverkit/pkg/kernelrelease"
 )
 
+//go:embed templates/fedora_kernel.sh
+var fedoraKernelTemplate string
+
 //go:embed templates/fedora.sh
 var fedoraTemplate string
 
@@ -37,13 +40,14 @@ type fedora struct {
 }
 
 type fedoraTemplateData struct {
-	commonTemplateData
 	KernelDownloadURL string
 }
 
 func (c *fedora) Name() string {
 	return TargetTypeFedora.String()
 }
+
+func (c *fedora) TemplateKernelUrlsScript() string { return fedoraKernelTemplate }
 
 func (c *fedora) TemplateScript() string {
 	return fedoraTemplate
@@ -87,9 +91,8 @@ func (c *fedora) URLs(kr kernelrelease.KernelRelease) ([]string, error) {
 	return urls, nil
 }
 
-func (c *fedora) TemplateData(cfg Config, kr kernelrelease.KernelRelease, urls []string) interface{} {
+func (c *fedora) KernelTemplateData(_ kernelrelease.KernelRelease, urls []string) interface{} {
 	return fedoraTemplateData{
-		commonTemplateData: cfg.toTemplateData(c, kr),
-		KernelDownloadURL:  urls[0],
+		KernelDownloadURL: urls[0],
 	}
 }

--- a/pkg/driverbuilder/builder/flatcar.go
+++ b/pkg/driverbuilder/builder/flatcar.go
@@ -25,6 +25,9 @@ import (
 	"github.com/falcosecurity/driverkit/pkg/kernelrelease"
 )
 
+//go:embed templates/flatcar_kernel.sh
+var flatcarKernelTemplate string
+
 //go:embed templates/flatcar.sh
 var flatcarTemplate string
 
@@ -36,7 +39,6 @@ func init() {
 }
 
 type flatcarTemplateData struct {
-	commonTemplateData
 	KernelDownloadURL string
 }
 
@@ -47,6 +49,10 @@ type flatcar struct {
 
 func (f *flatcar) Name() string {
 	return TargetTypeFlatcar.String()
+}
+
+func (f *flatcar) TemplateKernelUrlsScript() string {
+	return flatcarKernelTemplate
 }
 
 func (f *flatcar) TemplateScript() string {
@@ -60,7 +66,7 @@ func (f *flatcar) URLs(kr kernelrelease.KernelRelease) ([]string, error) {
 	return fetchFlatcarKernelURLS(f.info.KernelVersion), nil
 }
 
-func (f *flatcar) TemplateData(c Config, kr kernelrelease.KernelRelease, urls []string) interface{} {
+func (f *flatcar) KernelTemplateData(kr kernelrelease.KernelRelease, urls []string) interface{} {
 	// This happens when `kernelurls` option is passed,
 	// therefore URLs() method is not called.
 	if f.info == nil {
@@ -70,8 +76,7 @@ func (f *flatcar) TemplateData(c Config, kr kernelrelease.KernelRelease, urls []
 	}
 
 	return flatcarTemplateData{
-		commonTemplateData: c.toTemplateData(f, kr),
-		KernelDownloadURL:  urls[0],
+		KernelDownloadURL: urls[0],
 	}
 }
 

--- a/pkg/driverbuilder/builder/local.go
+++ b/pkg/driverbuilder/builder/local.go
@@ -24,6 +24,10 @@ func (l *LocalBuilder) Name() string {
 	return "local"
 }
 
+func (l *LocalBuilder) TemplateKernelUrlsScript() string {
+	panic("cannot be called on local builder")
+}
+
 func (l *LocalBuilder) TemplateScript() string {
 	return localTemplate
 }
@@ -45,16 +49,19 @@ type localTemplateData struct {
 	KernelRelease string
 }
 
-func (l *LocalBuilder) TemplateData(c Config, kr kernelrelease.KernelRelease, _ []string) interface{} {
+func (l *LocalBuilder) KernelTemplateData(_ kernelrelease.KernelRelease, _ []string) interface{} {
+	panic("cannot be called on local builder")
+}
+
+func (l *LocalBuilder) TemplateData(c Config, kr kernelrelease.KernelRelease) interface{} {
 	return localTemplateData{
 		commonTemplateData: commonTemplateData{
-			DriverBuildDir:    l.GetDriverBuildDir(),
-			ModuleDownloadURL: fmt.Sprintf("%s/%s.tar.gz", c.DownloadBaseURL, c.DriverVersion),
-			ModuleDriverName:  c.DriverName,
-			ModuleFullPath:    l.GetModuleFullPath(c, kr),
-			BuildModule:       len(c.ModuleFilePath) > 0,
-			BuildProbe:        len(c.ProbeFilePath) > 0,
-			GCCVersion:        l.GccPath,
+			DriverBuildDir:   l.GetDriverBuildDir(),
+			ModuleDriverName: c.DriverName,
+			ModuleFullPath:   l.GetModuleFullPath(c, kr),
+			BuildModule:      len(c.ModuleFilePath) > 0,
+			BuildProbe:       len(c.ProbeFilePath) > 0,
+			GCCVersion:       l.GccPath,
 			CmakeCmd: fmt.Sprintf(cmakeCmdFmt,
 				c.DriverName,
 				c.DriverName,

--- a/pkg/driverbuilder/builder/minikube.go
+++ b/pkg/driverbuilder/builder/minikube.go
@@ -36,9 +36,8 @@ func (m *minikube) Name() string {
 	return TargetTypeMinikube.String()
 }
 
-func (m *minikube) TemplateData(c Config, kr kernelrelease.KernelRelease, urls []string) interface{} {
+func (m *minikube) KernelTemplateData(kr kernelrelease.KernelRelease, urls []string) interface{} {
 	return vanillaTemplateData{
-		commonTemplateData: c.toTemplateData(m, kr),
 		KernelDownloadURL:  urls[0],
 		KernelLocalVersion: kr.FullExtraversion,
 	}

--- a/pkg/driverbuilder/builder/opensuse.go
+++ b/pkg/driverbuilder/builder/opensuse.go
@@ -22,6 +22,9 @@ import (
 	"github.com/falcosecurity/driverkit/pkg/kernelrelease"
 )
 
+//go:embed templates/opensuse_kernel.sh
+var opensuseKernelTemplate string
+
 //go:embed templates/opensuse.sh
 var opensuseTemplate string
 
@@ -44,7 +47,7 @@ var baseURLs []string = []string{
 }
 
 // all known releases - will need to expand as more are added
-var releases []string = []string{
+var releases = []string{
 	// openSUSE leap
 	"43.2",
 	"15.0",
@@ -69,7 +72,6 @@ type opensuse struct {
 }
 
 type opensuseTemplateData struct {
-	commonTemplateData
 	KernelDownloadURLs []string
 }
 
@@ -79,6 +81,10 @@ func (o *opensuse) MinimumURLs() int {
 
 func (o *opensuse) Name() string {
 	return TargetTypeOpenSUSE.String()
+}
+
+func (o *opensuse) TemplateKernelUrlsScript() string {
+	return opensuseKernelTemplate
 }
 
 func (o *opensuse) TemplateScript() string {
@@ -259,9 +265,8 @@ func validateURLs(urls []string, kernelDefaultDevelPattern string, kernelDevelNo
 
 }
 
-func (o *opensuse) TemplateData(cfg Config, kr kernelrelease.KernelRelease, urls []string) interface{} {
+func (o *opensuse) KernelTemplateData(_ kernelrelease.KernelRelease, urls []string) interface{} {
 	return opensuseTemplateData{
-		commonTemplateData: cfg.toTemplateData(o, kr),
 		KernelDownloadURLs: urls,
 	}
 }

--- a/pkg/driverbuilder/builder/oracle.go
+++ b/pkg/driverbuilder/builder/oracle.go
@@ -22,6 +22,9 @@ import (
 	"github.com/falcosecurity/driverkit/pkg/kernelrelease"
 )
 
+//go:embed templates/oracle_kernel.sh
+var oracleKernelTemplate string
+
 //go:embed templates/oracle.sh
 var oracleTemplate string
 
@@ -37,12 +40,15 @@ type oracle struct {
 }
 
 type oracleTemplateData struct {
-	commonTemplateData
 	KernelDownloadURL string
 }
 
 func (c *oracle) Name() string {
 	return TargetTypeoracle.String()
+}
+
+func (c *oracle) TemplateKernelUrlsScript() string {
+	return oracleKernelTemplate
 }
 
 func (c *oracle) TemplateScript() string {
@@ -119,9 +125,8 @@ func (c *oracle) URLs(kr kernelrelease.KernelRelease) ([]string, error) {
 	return urls, nil
 }
 
-func (c *oracle) TemplateData(cfg Config, kr kernelrelease.KernelRelease, urls []string) interface{} {
+func (c *oracle) KernelTemplateData(_ kernelrelease.KernelRelease, urls []string) interface{} {
 	return oracleTemplateData{
-		commonTemplateData: cfg.toTemplateData(c, kr),
-		KernelDownloadURL:  urls[0],
+		KernelDownloadURL: urls[0],
 	}
 }

--- a/pkg/driverbuilder/builder/photon.go
+++ b/pkg/driverbuilder/builder/photon.go
@@ -24,6 +24,9 @@ import (
 // TargetTypePhoton identifies the Photon target.
 const TargetTypePhoton Type = "photon"
 
+//go:embed templates/photonos_kernel.sh
+var photonKernelTemplate string
+
 //go:embed templates/photonos.sh
 var photonTemplate string
 
@@ -36,12 +39,15 @@ type photon struct {
 }
 
 type photonTemplateData struct {
-	commonTemplateData
 	KernelDownloadURL string
 }
 
 func (p *photon) Name() string {
 	return TargetTypePhoton.String()
+}
+
+func (p *photon) TemplateKernelUrlsScript() string {
+	return photonKernelTemplate
 }
 
 func (p *photon) TemplateScript() string {
@@ -52,10 +58,9 @@ func (p *photon) URLs(kr kernelrelease.KernelRelease) ([]string, error) {
 	return fetchPhotonKernelURLS(kr), nil
 }
 
-func (p *photon) TemplateData(cfg Config, kr kernelrelease.KernelRelease, urls []string) interface{} {
+func (p *photon) KernelTemplateData(_ kernelrelease.KernelRelease, urls []string) interface{} {
 	return photonTemplateData{
-		commonTemplateData: cfg.toTemplateData(p, kr),
-		KernelDownloadURL:  urls[0],
+		KernelDownloadURL: urls[0],
 	}
 }
 

--- a/pkg/driverbuilder/builder/redhat.go
+++ b/pkg/driverbuilder/builder/redhat.go
@@ -20,6 +20,9 @@ import (
 	"github.com/falcosecurity/driverkit/pkg/kernelrelease"
 )
 
+//go:embed templates/redhat_kernel.sh
+var redhatKernelTemplate string
+
 //go:embed templates/redhat.sh
 var redhatTemplate string
 
@@ -35,7 +38,6 @@ func init() {
 }
 
 type redhatTemplateData struct {
-	commonTemplateData
 	KernelPackage string
 }
 
@@ -43,11 +45,15 @@ func (v *redhat) Name() string {
 	return TargetTypeRedhat.String()
 }
 
+func (v *redhat) TemplateKernelUrlsScript() string {
+	return redhatKernelTemplate
+}
+
 func (v *redhat) TemplateScript() string {
 	return redhatTemplate
 }
 
-func (v *redhat) URLs(kr kernelrelease.KernelRelease) ([]string, error) {
+func (v *redhat) URLs(_ kernelrelease.KernelRelease) ([]string, error) {
 	return nil, nil
 }
 
@@ -56,9 +62,8 @@ func (v *redhat) MinimumURLs() int {
 	return 0
 }
 
-func (v *redhat) TemplateData(c Config, kr kernelrelease.KernelRelease, _ []string) interface{} {
+func (v *redhat) KernelTemplateData(kr kernelrelease.KernelRelease, _ []string) interface{} {
 	return redhatTemplateData{
-		commonTemplateData: c.toTemplateData(v, kr),
-		KernelPackage:      kr.Fullversion + kr.FullExtraversion,
+		KernelPackage: kr.Fullversion + kr.FullExtraversion,
 	}
 }

--- a/pkg/driverbuilder/builder/rocky.go
+++ b/pkg/driverbuilder/builder/rocky.go
@@ -21,6 +21,9 @@ import (
 	"github.com/falcosecurity/driverkit/pkg/kernelrelease"
 )
 
+//go:embed templates/rocky_kernel.sh
+var rockyKernelTemplate string
+
 //go:embed templates/rocky.sh
 var rockyTemplate string
 
@@ -32,7 +35,6 @@ func init() {
 }
 
 type rockyTemplateData struct {
-	commonTemplateData
 	KernelDownloadURL string
 }
 
@@ -44,6 +46,10 @@ func (c *rocky) Name() string {
 	return TargetTypeRocky.String()
 }
 
+func (c *rocky) TemplateKernelUrlsScript() string {
+	return rockyKernelTemplate
+}
+
 func (c *rocky) TemplateScript() string {
 	return rockyTemplate
 }
@@ -52,10 +58,9 @@ func (c *rocky) URLs(kr kernelrelease.KernelRelease) ([]string, error) {
 	return fetchRockyKernelURLS(kr), nil
 }
 
-func (c *rocky) TemplateData(cfg Config, kr kernelrelease.KernelRelease, urls []string) interface{} {
+func (c *rocky) KernelTemplateData(_ kernelrelease.KernelRelease, urls []string) interface{} {
 	return rockyTemplateData{
-		commonTemplateData: cfg.toTemplateData(c, kr),
-		KernelDownloadURL:  urls[0],
+		KernelDownloadURL: urls[0],
 	}
 }
 

--- a/pkg/driverbuilder/builder/sles.go
+++ b/pkg/driverbuilder/builder/sles.go
@@ -20,6 +20,9 @@ import (
 	"github.com/falcosecurity/driverkit/pkg/kernelrelease"
 )
 
+//go:embed templates/sles_kernel.sh
+var slesKernelTemplate string
+
 //go:embed templates/sles.sh
 var slesTemplate string
 
@@ -35,7 +38,6 @@ func init() {
 }
 
 type slesTemplateData struct {
-	commonTemplateData
 	KernelPackage string
 }
 
@@ -43,11 +45,15 @@ func (v *sles) Name() string {
 	return TargetTypeSLES.String()
 }
 
+func (v *sles) TemplateKernelUrlsScript() string {
+	return slesKernelTemplate
+}
+
 func (v *sles) TemplateScript() string {
 	return slesTemplate
 }
 
-func (v *sles) URLs(kr kernelrelease.KernelRelease) ([]string, error) {
+func (v *sles) URLs(_ kernelrelease.KernelRelease) ([]string, error) {
 	return nil, nil
 }
 
@@ -56,10 +62,9 @@ func (v *sles) MinimumURLs() int {
 	return 0
 }
 
-func (v *sles) TemplateData(c Config, kr kernelrelease.KernelRelease, _ []string) interface{} {
+func (v *sles) KernelTemplateData(kr kernelrelease.KernelRelease, _ []string) interface{} {
 	return slesTemplateData{
-		commonTemplateData: c.toTemplateData(v, kr),
-		KernelPackage:      kr.Fullversion + kr.FullExtraversion,
+		KernelPackage: kr.Fullversion + kr.FullExtraversion,
 	}
 }
 

--- a/pkg/driverbuilder/builder/talos.go
+++ b/pkg/driverbuilder/builder/talos.go
@@ -35,9 +35,8 @@ func (b *talos) Name() string {
 	return TargetTypeTalos.String()
 }
 
-func (b *talos) TemplateData(c Config, kr kernelrelease.KernelRelease, urls []string) interface{} {
+func (b *talos) KernelTemplateData(kr kernelrelease.KernelRelease, urls []string) interface{} {
 	return vanillaTemplateData{
-		commonTemplateData: c.toTemplateData(b, kr),
 		KernelDownloadURL:  urls[0],
 		KernelLocalVersion: kr.FullExtraversion,
 	}

--- a/pkg/driverbuilder/builder/templates/alinux.sh
+++ b/pkg/driverbuilder/builder/templates/alinux.sh
@@ -22,30 +22,13 @@
 #
 set -xeuo pipefail
 
-rm -Rf {{ .DriverBuildDir }}
-mkdir {{ .DriverBuildDir }}
-rm -Rf /tmp/module-download
-mkdir -p /tmp/module-download
-
-curl --silent -SL {{ .ModuleDownloadURL }} | tar -xzf - -C /tmp/module-download
-mv /tmp/module-download/*/* {{ .DriverBuildDir }}
-
-# Fetch the kernel
-mkdir /tmp/kernel-download
-cd /tmp/kernel-download
-curl --silent -o kernel-devel.rpm -SL {{ .KernelDownloadURL }}
-rpm2cpio kernel-devel.rpm | cpio --extract --make-directories
-rm -Rf /tmp/kernel
-mkdir -p /tmp/kernel
-mv usr/src/kernels/*/* /tmp/kernel
-
 cd {{ .DriverBuildDir }}
 mkdir -p build && cd build
 {{ .CmakeCmd }}
 
 {{ if .BuildModule }}
 # Build the module
-make CC=/usr/bin/gcc-{{ .GCCVersion }} KERNELDIR=/tmp/kernel driver
+make CC=/usr/bin/gcc-{{ .GCCVersion }} driver
 strip -g {{ .ModuleFullPath }}
 # Print results
 modinfo {{ .ModuleFullPath }}
@@ -53,6 +36,6 @@ modinfo {{ .ModuleFullPath }}
 
 {{ if .BuildProbe }}
 # Build the eBPF probe
-make KERNELDIR=/tmp/kernel bpf
+make bpf
 ls -l driver/bpf/probe.o
 {{ end }}

--- a/pkg/driverbuilder/builder/templates/alinux_kernel.sh
+++ b/pkg/driverbuilder/builder/templates/alinux_kernel.sh
@@ -22,20 +22,14 @@
 #
 set -xeuo pipefail
 
-cd {{ .DriverBuildDir }}
-mkdir -p build && cd build
-{{ .CmakeCmd }}
+# Fetch the kernel
+mkdir /tmp/kernel-download
+cd /tmp/kernel-download
+curl --silent -o kernel-devel.rpm -SL {{ .KernelDownloadURL }}
+rpm2cpio kernel-devel.rpm | cpio --extract --make-directories
+rm -Rf /tmp/kernel
+mkdir -p /tmp/kernel
+mv usr/src/kernels/*/* /tmp/kernel
 
-{{ if .BuildModule }}
-# Build the module
-make CC=/usr/bin/gcc-{{ .GCCVersion }} LD=/usr/bin/ld.bfd CROSS_COMPILE="" driver
-strip -g {{ .ModuleFullPath }}
-# Print results
-modinfo {{ .ModuleFullPath }}
-{{ end }}
-
-{{ if .BuildProbe }}
-# Build the eBPF probe
-make bpf
-ls -l driver/bpf/probe.o
-{{ end }}
+# exit value
+echo /tmp/kernel

--- a/pkg/driverbuilder/builder/templates/almalinux.sh
+++ b/pkg/driverbuilder/builder/templates/almalinux.sh
@@ -22,30 +22,13 @@
 #
 set -xeuo pipefail
 
-rm -Rf {{ .DriverBuildDir }}
-mkdir {{ .DriverBuildDir }}
-rm -Rf /tmp/module-download
-mkdir -p /tmp/module-download
-
-curl --silent -SL {{ .ModuleDownloadURL }} | tar -xzf - -C /tmp/module-download
-mv /tmp/module-download/*/* {{ .DriverBuildDir }}
-
-# Fetch the kernel
-mkdir /tmp/kernel-download
-cd /tmp/kernel-download
-curl --silent -o kernel-devel.rpm -SL {{ .KernelDownloadURL }}
-rpm2cpio kernel-devel.rpm | cpio --extract --make-directories
-rm -Rf /tmp/kernel
-mkdir -p /tmp/kernel
-mv usr/src/kernels/*/* /tmp/kernel
-
 cd {{ .DriverBuildDir }}
 mkdir -p build && cd build
 {{ .CmakeCmd }}
 
 {{ if .BuildModule }}
 # Build the module
-make CC=/usr/bin/gcc-{{ .GCCVersion }} KERNELDIR=/tmp/kernel driver
+make CC=/usr/bin/gcc-{{ .GCCVersion }} driver
 strip -g {{ .ModuleFullPath }}
 # Print results
 modinfo {{ .ModuleFullPath }}
@@ -53,6 +36,6 @@ modinfo {{ .ModuleFullPath }}
 
 {{ if .BuildProbe }}
 # Build the eBPF probe
-make KERNELDIR=/tmp/kernel bpf
+make bpf
 ls -l driver/bpf/probe.o
 {{ end }}

--- a/pkg/driverbuilder/builder/templates/almalinux_kernel.sh
+++ b/pkg/driverbuilder/builder/templates/almalinux_kernel.sh
@@ -22,20 +22,14 @@
 #
 set -xeuo pipefail
 
-cd {{ .DriverBuildDir }}
-mkdir -p build && cd build
-{{ .CmakeCmd }}
+# Fetch the kernel
+mkdir /tmp/kernel-download
+cd /tmp/kernel-download
+curl --silent -o kernel-devel.rpm -SL {{ .KernelDownloadURL }}
+rpm2cpio kernel-devel.rpm | cpio --extract --make-directories
+rm -Rf /tmp/kernel
+mkdir -p /tmp/kernel
+mv usr/src/kernels/*/* /tmp/kernel
 
-{{ if .BuildModule }}
-# Build the module
-make CC=/usr/bin/gcc-{{ .GCCVersion }} LD=/usr/bin/ld.bfd CROSS_COMPILE="" driver
-strip -g {{ .ModuleFullPath }}
-# Print results
-modinfo {{ .ModuleFullPath }}
-{{ end }}
-
-{{ if .BuildProbe }}
-# Build the eBPF probe
-make bpf
-ls -l driver/bpf/probe.o
-{{ end }}
+# exit value
+echo /tmp/kernel

--- a/pkg/driverbuilder/builder/templates/amazonlinux_kernel.sh
+++ b/pkg/driverbuilder/builder/templates/amazonlinux_kernel.sh
@@ -22,20 +22,17 @@
 #
 set -xeuo pipefail
 
-cd {{ .DriverBuildDir }}
-mkdir -p build && cd build
-{{ .CmakeCmd }}
-
-{{ if .BuildModule }}
-# Build the module
-make CC=/usr/bin/gcc-{{ .GCCVersion }} LD=/usr/bin/ld.bfd CROSS_COMPILE="" driver
-strip -g {{ .ModuleFullPath }}
-# Print results
-modinfo {{ .ModuleFullPath }}
+# Fetch the kernel
+mkdir /tmp/kernel-download
+cd /tmp/kernel-download
+{{ range $url := .KernelDownloadURLs }}
+curl --silent -o kernel.rpm -SL {{ $url }}
+rpm2cpio kernel.rpm | cpio --extract --make-directories
+rm -rf kernel.rpm
 {{ end }}
+rm -Rf /tmp/kernel
+mkdir -p /tmp/kernel
+mv usr/src/kernels/*/* /tmp/kernel
 
-{{ if .BuildProbe }}
-# Build the eBPF probe
-make bpf
-ls -l driver/bpf/probe.o
-{{ end }}
+# exit value
+echo /tmp/kernel

--- a/pkg/driverbuilder/builder/templates/archlinux.sh
+++ b/pkg/driverbuilder/builder/templates/archlinux.sh
@@ -22,30 +22,13 @@
 #
 set -xeuo pipefail
 
-rm -Rf {{ .DriverBuildDir }}
-mkdir {{ .DriverBuildDir }}
-rm -Rf /tmp/module-download
-mkdir -p /tmp/module-download
-
-curl --silent -SL {{ .ModuleDownloadURL }} | tar -xzf - -C /tmp/module-download
-mv /tmp/module-download/*/* {{ .DriverBuildDir }}
-
-# Fetch the kernel
-mkdir /tmp/kernel-download
-cd /tmp/kernel-download
-curl --silent -o kernel-devel.pkg.tar.xz -SL {{ .KernelDownloadURL }}
-tar -xf kernel-devel.pkg.tar.xz
-rm -Rf /tmp/kernel
-mkdir -p /tmp/kernel
-mv usr/lib/modules/*/build/* /tmp/kernel
-
 cd {{ .DriverBuildDir }}
 mkdir -p build && cd build
 {{ .CmakeCmd }}
 
 {{ if .BuildModule }}
 # Build the module
-make CC=/usr/bin/gcc-{{ .GCCVersion }} KERNELDIR=/tmp/kernel driver
+make CC=/usr/bin/gcc-{{ .GCCVersion }} driver
 strip -g {{ .ModuleFullPath }}
 # Print results
 modinfo {{ .ModuleFullPath }}
@@ -53,6 +36,6 @@ modinfo {{ .ModuleFullPath }}
 
 {{ if .BuildProbe }}
 # Build the eBPF probe
-make KERNELDIR=/tmp/kernel bpf
+make bpf
 ls -l driver/bpf/probe.o
 {{ end }}

--- a/pkg/driverbuilder/builder/templates/archlinux_kernel.sh
+++ b/pkg/driverbuilder/builder/templates/archlinux_kernel.sh
@@ -22,20 +22,14 @@
 #
 set -xeuo pipefail
 
-cd {{ .DriverBuildDir }}
-mkdir -p build && cd build
-{{ .CmakeCmd }}
+# Fetch the kernel
+mkdir /tmp/kernel-download
+cd /tmp/kernel-download
+curl --silent -o kernel-devel.pkg.tar.xz -SL {{ .KernelDownloadURL }}
+tar -xf kernel-devel.pkg.tar.xz
+rm -Rf /tmp/kernel
+mkdir -p /tmp/kernel
+mv usr/lib/modules/*/build/* /tmp/kernel
 
-{{ if .BuildModule }}
-# Build the module
-make CC=/usr/bin/gcc-{{ .GCCVersion }} LD=/usr/bin/ld.bfd CROSS_COMPILE="" driver
-strip -g {{ .ModuleFullPath }}
-# Print results
-modinfo {{ .ModuleFullPath }}
-{{ end }}
-
-{{ if .BuildProbe }}
-# Build the eBPF probe
-make bpf
-ls -l driver/bpf/probe.o
-{{ end }}
+# exit value
+echo /tmp/kernel

--- a/pkg/driverbuilder/builder/templates/centos_kernel.sh
+++ b/pkg/driverbuilder/builder/templates/centos_kernel.sh
@@ -22,20 +22,14 @@
 #
 set -xeuo pipefail
 
-cd {{ .DriverBuildDir }}
-mkdir -p build && cd build
-{{ .CmakeCmd }}
+# Fetch the kernel
+mkdir /tmp/kernel-download
+cd /tmp/kernel-download
+curl --silent -o kernel-devel.rpm -SL {{ .KernelDownloadURL }}
+rpm2cpio kernel-devel.rpm | cpio --extract --make-directories
+rm -Rf /tmp/kernel
+mkdir -p /tmp/kernel
+mv usr/src/kernels/*/* /tmp/kernel
 
-{{ if .BuildModule }}
-# Build the module
-make CC=/usr/bin/gcc-{{ .GCCVersion }} LD=/usr/bin/ld.bfd CROSS_COMPILE="" driver
-strip -g {{ .ModuleFullPath }}
-# Print results
-modinfo {{ .ModuleFullPath }}
-{{ end }}
-
-{{ if .BuildProbe }}
-# Build the eBPF probe
-make bpf
-ls -l driver/bpf/probe.o
-{{ end }}
+# exit value
+echo /tmp/kernel

--- a/pkg/driverbuilder/builder/templates/debian.sh
+++ b/pkg/driverbuilder/builder/templates/debian.sh
@@ -22,38 +22,13 @@
 #
 set -xeuo pipefail
 
-rm -Rf {{ .DriverBuildDir }}
-mkdir {{ .DriverBuildDir }}
-rm -Rf /tmp/module-download
-mkdir -p /tmp/module-download
-
-curl --silent -SL {{ .ModuleDownloadURL }} | tar -xzf - -C /tmp/module-download
-mv /tmp/module-download/*/* {{ .DriverBuildDir }}
-
-# Fetch the kernel
-mkdir /tmp/kernel-download
-cd /tmp/kernel-download
-{{ range $url := .KernelDownloadURLS }}
-curl --silent -o kernel.deb -SL {{ $url }}
-ar x kernel.deb
-tar -xf data.tar.xz
-{{ end }}
-
-cd /tmp/kernel-download/
-
-cp -r usr/* /usr
-cp -r lib/* /lib
-
-cd /usr/src
-sourcedir=$(find . -type d -name "{{ .KernelHeadersPattern }}" | head -n 1 | xargs readlink -f)
-
 cd {{ .DriverBuildDir }}
 mkdir -p build && cd build
 {{ .CmakeCmd }}
 
 {{ if .BuildModule }}
 # Build the module
-make CC=/usr/bin/gcc-{{ .GCCVersion }} KERNELDIR=$sourcedir driver
+make CC=/usr/bin/gcc-{{ .GCCVersion }} driver
 strip -g {{ .ModuleFullPath }}
 # Print results
 modinfo {{ .ModuleFullPath }}
@@ -61,6 +36,6 @@ modinfo {{ .ModuleFullPath }}
 
 {{ if .BuildProbe }}
 # Build the eBPF probe
-make KERNELDIR=$sourcedir bpf
+make bpf
 ls -l driver/bpf/probe.o
 {{ end }}

--- a/pkg/driverbuilder/builder/templates/debian_kernel.sh
+++ b/pkg/driverbuilder/builder/templates/debian_kernel.sh
@@ -30,8 +30,12 @@ curl --silent -o kernel.deb -SL {{ $url }}
 ar x kernel.deb
 tar -xf data.tar.xz
 {{ end }}
+
 cd usr/src/
 sourcedir=$(find . -type d -name "{{ .KernelHeadersPattern }}" | head -n 1 | xargs readlink -f)
+
+# Patch makefile to avoid using absolute `/usr/src` path; instead use `..` relative one.
+sed -i 's/\/usr\/src/../g' $sourcedir/Makefile
 
 # exit value
 echo $sourcedir

--- a/pkg/driverbuilder/builder/templates/debian_kernel.sh
+++ b/pkg/driverbuilder/builder/templates/debian_kernel.sh
@@ -22,20 +22,16 @@
 #
 set -xeuo pipefail
 
-cd {{ .DriverBuildDir }}
-mkdir -p build && cd build
-{{ .CmakeCmd }}
-
-{{ if .BuildModule }}
-# Build the module
-make CC=/usr/bin/gcc-{{ .GCCVersion }} LD=/usr/bin/ld.bfd CROSS_COMPILE="" driver
-strip -g {{ .ModuleFullPath }}
-# Print results
-modinfo {{ .ModuleFullPath }}
+# Fetch the kernel
+mkdir /tmp/kernel-download
+cd /tmp/kernel-download
+{{ range $url := .KernelDownloadURLS }}
+curl --silent -o kernel.deb -SL {{ $url }}
+ar x kernel.deb
+tar -xf data.tar.xz
 {{ end }}
+cd usr/src/
+sourcedir=$(find . -type d -name "{{ .KernelHeadersPattern }}" | head -n 1 | xargs readlink -f)
 
-{{ if .BuildProbe }}
-# Build the eBPF probe
-make bpf
-ls -l driver/bpf/probe.o
-{{ end }}
+# exit value
+echo $sourcedir

--- a/pkg/driverbuilder/builder/templates/fedora.sh
+++ b/pkg/driverbuilder/builder/templates/fedora.sh
@@ -22,30 +22,13 @@
 #
 set -xeuo pipefail
 
-rm -Rf {{ .DriverBuildDir }}
-mkdir {{ .DriverBuildDir }}
-rm -Rf /tmp/module-download
-mkdir -p /tmp/module-download
-
-curl --silent -SL {{ .ModuleDownloadURL }} | tar -xzf - -C /tmp/module-download
-mv /tmp/module-download/*/* {{ .DriverBuildDir }}
-
-# Fetch the kernel
-mkdir /tmp/kernel-download
-cd /tmp/kernel-download
-curl --silent -o kernel-devel.rpm -SL {{ .KernelDownloadURL }}
-rpm2cpio kernel-devel.rpm | cpio --extract --make-directories
-rm -Rf /tmp/kernel
-mkdir -p /tmp/kernel
-mv usr/src/kernels/*/* /tmp/kernel
-
 cd {{ .DriverBuildDir }}
 mkdir -p build && cd build
 {{ .CmakeCmd }}
 
 {{ if .BuildModule }}
 # Build the module
-make CC=/usr/bin/gcc-{{ .GCCVersion }} KERNELDIR=/tmp/kernel driver
+make CC=/usr/bin/gcc-{{ .GCCVersion }} driver
 strip -g {{ .ModuleFullPath }}
 # Print results
 modinfo {{ .ModuleFullPath }}
@@ -53,6 +36,6 @@ modinfo {{ .ModuleFullPath }}
 
 {{ if .BuildProbe }}
 # Build the eBPF probe
-make KERNELDIR=/tmp/kernel bpf
+make bpf
 ls -l driver/bpf/probe.o
 {{ end }}

--- a/pkg/driverbuilder/builder/templates/fedora_kernel.sh
+++ b/pkg/driverbuilder/builder/templates/fedora_kernel.sh
@@ -22,20 +22,14 @@
 #
 set -xeuo pipefail
 
-cd {{ .DriverBuildDir }}
-mkdir -p build && cd build
-{{ .CmakeCmd }}
+# Fetch the kernel
+mkdir /tmp/kernel-download
+cd /tmp/kernel-download
+curl --silent -o kernel-devel.rpm -SL {{ .KernelDownloadURL }}
+rpm2cpio kernel-devel.rpm | cpio --extract --make-directories
+rm -Rf /tmp/kernel
+mkdir -p /tmp/kernel
+mv usr/src/kernels/*/* /tmp/kernel
 
-{{ if .BuildModule }}
-# Build the module
-make CC=/usr/bin/gcc-{{ .GCCVersion }} LD=/usr/bin/ld.bfd CROSS_COMPILE="" driver
-strip -g {{ .ModuleFullPath }}
-# Print results
-modinfo {{ .ModuleFullPath }}
-{{ end }}
-
-{{ if .BuildProbe }}
-# Build the eBPF probe
-make bpf
-ls -l driver/bpf/probe.o
-{{ end }}
+# exit value
+echo /tmp/kernel

--- a/pkg/driverbuilder/builder/templates/libs_download.sh
+++ b/pkg/driverbuilder/builder/templates/libs_download.sh
@@ -22,20 +22,12 @@
 #
 set -xeuo pipefail
 
-cd {{ .DriverBuildDir }}
-mkdir -p build && cd build
-{{ .CmakeCmd }}
+rm -Rf {{ .DriverBuildDir }}
+mkdir {{ .DriverBuildDir }}
+rm -Rf /tmp/module-download
+mkdir -p /tmp/module-download
 
-{{ if .BuildModule }}
-# Build the module
-make CC=/usr/bin/gcc-{{ .GCCVersion }} LD=/usr/bin/ld.bfd CROSS_COMPILE="" driver
-strip -g {{ .ModuleFullPath }}
-# Print results
-modinfo {{ .ModuleFullPath }}
-{{ end }}
+curl --silent -SL {{ .ModuleDownloadURL }} | tar -xzf - -C /tmp/module-download
+mv /tmp/module-download/*/* {{ .DriverBuildDir }}
 
-{{ if .BuildProbe }}
-# Build the eBPF probe
-make bpf
-ls -l driver/bpf/probe.o
-{{ end }}
+rm -Rf /tmp/module-download

--- a/pkg/driverbuilder/builder/templates/oracle.sh
+++ b/pkg/driverbuilder/builder/templates/oracle.sh
@@ -22,30 +22,13 @@
 #
 set -xeuo pipefail
 
-rm -Rf {{ .DriverBuildDir }}
-mkdir {{ .DriverBuildDir }}
-rm -Rf /tmp/module-download
-mkdir -p /tmp/module-download
-
-curl --silent -SL {{ .ModuleDownloadURL }} | tar -xzf - -C /tmp/module-download
-mv /tmp/module-download/*/* {{ .DriverBuildDir }}
-
-# Fetch the kernel
-mkdir /tmp/kernel-download
-cd /tmp/kernel-download
-curl --silent -o kernel-devel.rpm -SL {{ .KernelDownloadURL }}
-rpm2cpio kernel-devel.rpm | cpio --extract --make-directories
-rm -Rf /tmp/kernel
-mkdir -p /tmp/kernel
-mv usr/src/kernels/*/* /tmp/kernel
-
 cd {{ .DriverBuildDir }}
 mkdir -p build && cd build
 {{ .CmakeCmd }}
 
 {{ if .BuildModule }}
 # Build the module
-make CC=/usr/bin/gcc-{{ .GCCVersion }} KERNELDIR=/tmp/kernel driver
+make CC=/usr/bin/gcc-{{ .GCCVersion }} driver
 strip -g {{ .ModuleFullPath }}
 # Print results
 modinfo {{ .ModuleFullPath }}
@@ -53,6 +36,6 @@ modinfo {{ .ModuleFullPath }}
 
 {{ if .BuildProbe }}
 # Build the eBPF probe
-make KERNELDIR=/tmp/kernel bpf
+make bpf
 ls -l driver/bpf/probe.o
 {{ end }}

--- a/pkg/driverbuilder/builder/templates/oracle_kernel.sh
+++ b/pkg/driverbuilder/builder/templates/oracle_kernel.sh
@@ -22,20 +22,14 @@
 #
 set -xeuo pipefail
 
-cd {{ .DriverBuildDir }}
-mkdir -p build && cd build
-{{ .CmakeCmd }}
+# Fetch the kernel
+mkdir /tmp/kernel-download
+cd /tmp/kernel-download
+curl --silent -o kernel-devel.rpm -SL {{ .KernelDownloadURL }}
+rpm2cpio kernel-devel.rpm | cpio --extract --make-directories
+rm -Rf /tmp/kernel
+mkdir -p /tmp/kernel
+mv usr/src/kernels/*/* /tmp/kernel
 
-{{ if .BuildModule }}
-# Build the module
-make CC=/usr/bin/gcc-{{ .GCCVersion }} LD=/usr/bin/ld.bfd CROSS_COMPILE="" driver
-strip -g {{ .ModuleFullPath }}
-# Print results
-modinfo {{ .ModuleFullPath }}
-{{ end }}
-
-{{ if .BuildProbe }}
-# Build the eBPF probe
-make bpf
-ls -l driver/bpf/probe.o
-{{ end }}
+# exit value
+echo /tmp/kernel

--- a/pkg/driverbuilder/builder/templates/photonos_kernel.sh
+++ b/pkg/driverbuilder/builder/templates/photonos_kernel.sh
@@ -22,20 +22,17 @@
 #
 set -xeuo pipefail
 
-cd {{ .DriverBuildDir }}
-mkdir -p build && cd build
-{{ .CmakeCmd }}
+# Fetch the kernel
+mkdir /tmp/kernel-download
+cd /tmp/kernel-download
+curl --silent -o kernel-devel.rpm -SL {{ .KernelDownloadURL }}
+rpm2cpio kernel-devel.rpm | cpio --extract --make-directories
+rm -Rf /tmp/kernel
+mkdir -p /tmp/kernel
+# eg: linux-aws-headers-$kernelrelease
+# eg: linux-headers-$kernelrelease-rt
+# eg: linux-headers-$kernelrelease
+mv usr/src/linux-*headers-*/* /tmp/kernel
 
-{{ if .BuildModule }}
-# Build the module
-make CC=/usr/bin/gcc-{{ .GCCVersion }} LD=/usr/bin/ld.bfd CROSS_COMPILE="" driver
-strip -g {{ .ModuleFullPath }}
-# Print results
-modinfo {{ .ModuleFullPath }}
-{{ end }}
-
-{{ if .BuildProbe }}
-# Build the eBPF probe
-make bpf
-ls -l driver/bpf/probe.o
-{{ end }}
+# exit value
+echo /tmp/kernel

--- a/pkg/driverbuilder/builder/templates/redhat_kernel.sh
+++ b/pkg/driverbuilder/builder/templates/redhat_kernel.sh
@@ -22,20 +22,16 @@
 #
 set -xeuo pipefail
 
-cd {{ .DriverBuildDir }}
-mkdir -p build && cd build
-{{ .CmakeCmd }}
+# Fetch the kernel
+rm -Rf /tmp/kernel-download
+mkdir /tmp/kernel-download
+cd /tmp/kernel-download
+yum install -y --downloadonly --downloaddir=/tmp/kernel-download kernel-devel-0:{{ .KernelPackage }}
+rpm2cpio kernel-devel-{{ .KernelPackage }}.rpm | cpio --extract --make-directories
 
-{{ if .BuildModule }}
-# Build the module
-make CC=/usr/bin/gcc-{{ .GCCVersion }} LD=/usr/bin/ld.bfd CROSS_COMPILE="" driver
-strip -g {{ .ModuleFullPath }}
-# Print results
-modinfo {{ .ModuleFullPath }}
-{{ end }}
+rm -Rf /tmp/kernel
+mkdir -p /tmp/kernel
+mv usr/src/kernels/*/* /tmp/kernel
 
-{{ if .BuildProbe }}
-# Build the eBPF probe
-make bpf
-ls -l driver/bpf/probe.o
-{{ end }}
+# exit value
+echo /tmp/kernel

--- a/pkg/driverbuilder/builder/templates/rocky.sh
+++ b/pkg/driverbuilder/builder/templates/rocky.sh
@@ -22,30 +22,13 @@
 #
 set -xeuo pipefail
 
-rm -Rf {{ .DriverBuildDir }}
-mkdir {{ .DriverBuildDir }}
-rm -Rf /tmp/module-download
-mkdir -p /tmp/module-download
-
-curl --silent -SL {{ .ModuleDownloadURL }} | tar -xzf - -C /tmp/module-download
-mv /tmp/module-download/*/* {{ .DriverBuildDir }}
-
-# Fetch the kernel
-mkdir /tmp/kernel-download
-cd /tmp/kernel-download
-curl --silent -o kernel-devel.rpm -SL {{ .KernelDownloadURL }}
-rpm2cpio kernel-devel.rpm | cpio --extract --make-directories
-rm -Rf /tmp/kernel
-mkdir -p /tmp/kernel
-mv usr/src/kernels/*/* /tmp/kernel
-
 cd {{ .DriverBuildDir }}
 mkdir -p build && cd build
 {{ .CmakeCmd }}
 
 {{ if .BuildModule }}
 # Build the module
-make CC=/usr/bin/gcc-{{ .GCCVersion }} KERNELDIR=/tmp/kernel driver
+make CC=/usr/bin/gcc-{{ .GCCVersion }} driver
 strip -g {{ .ModuleFullPath }}
 # Print results
 modinfo {{ .ModuleFullPath }}
@@ -53,6 +36,6 @@ modinfo {{ .ModuleFullPath }}
 
 {{ if .BuildProbe }}
 # Build the eBPF probe
-make KERNELDIR=/tmp/kernel bpf
+make bpf
 ls -l driver/bpf/probe.o
 {{ end }}

--- a/pkg/driverbuilder/builder/templates/rocky_kernel.sh
+++ b/pkg/driverbuilder/builder/templates/rocky_kernel.sh
@@ -22,20 +22,14 @@
 #
 set -xeuo pipefail
 
-cd {{ .DriverBuildDir }}
-mkdir -p build && cd build
-{{ .CmakeCmd }}
+# Fetch the kernel
+mkdir /tmp/kernel-download
+cd /tmp/kernel-download
+curl --silent -o kernel-devel.rpm -SL {{ .KernelDownloadURL }}
+rpm2cpio kernel-devel.rpm | cpio --extract --make-directories
+rm -Rf /tmp/kernel
+mkdir -p /tmp/kernel
+mv usr/src/kernels/*/* /tmp/kernel
 
-{{ if .BuildModule }}
-# Build the module
-make CC=/usr/bin/gcc-{{ .GCCVersion }} LD=/usr/bin/ld.bfd CROSS_COMPILE="" driver
-strip -g {{ .ModuleFullPath }}
-# Print results
-modinfo {{ .ModuleFullPath }}
-{{ end }}
-
-{{ if .BuildProbe }}
-# Build the eBPF probe
-make bpf
-ls -l driver/bpf/probe.o
-{{ end }}
+# exit value
+echo /tmp/kernel

--- a/pkg/driverbuilder/builder/templates/ubuntu.sh
+++ b/pkg/driverbuilder/builder/templates/ubuntu.sh
@@ -22,33 +22,13 @@
 #
 set -xeuo pipefail
 
-rm -Rf {{ .DriverBuildDir }}
-mkdir {{ .DriverBuildDir }}
-rm -Rf /tmp/module-download
-mkdir -p /tmp/module-download
-
-curl --silent -SL {{ .ModuleDownloadURL }} | tar -xzf - -C /tmp/module-download
-mv /tmp/module-download/*/* {{ .DriverBuildDir }}
-
-# Fetch the kernel
-mkdir /tmp/kernel-download
-cd /tmp/kernel-download
-{{range $url := .KernelDownloadURLS}}
-curl --silent -o kernel.deb -SL {{ $url }}
-ar x kernel.deb
-tar -xf data.tar.*
-{{end}}
-
-cd /tmp/kernel-download/usr/src/
-sourcedir=$(find . -type d -name "{{ .KernelHeadersPattern }}" | head -n 1 | xargs readlink -f)
-
 cd {{ .DriverBuildDir }}
 mkdir -p build && cd build
 {{ .CmakeCmd }}
 
 {{ if .BuildModule }}
 # Build the module
-make CC=/usr/bin/gcc-{{ .GCCVersion }} KERNELDIR=$sourcedir driver
+make CC=/usr/bin/gcc-{{ .GCCVersion }} driver
 strip -g {{ .ModuleFullPath }}
 # Print results
 modinfo {{ .ModuleFullPath }}
@@ -56,6 +36,6 @@ modinfo {{ .ModuleFullPath }}
 
 {{ if .BuildProbe }}
 # Build the eBPF probe
-make KERNELDIR=$sourcedir bpf
+make bpf
 ls -l driver/bpf/probe.o
 {{ end }}

--- a/pkg/driverbuilder/builder/templates/ubuntu_kernel.sh
+++ b/pkg/driverbuilder/builder/templates/ubuntu_kernel.sh
@@ -22,20 +22,16 @@
 #
 set -xeuo pipefail
 
-cd {{ .DriverBuildDir }}
-mkdir -p build && cd build
-{{ .CmakeCmd }}
+# Fetch the kernel
+mkdir /tmp/kernel-download
+cd /tmp/kernel-download
+{{range $url := .KernelDownloadURLS}}
+curl --silent -o kernel.deb -SL {{ $url }}
+ar x kernel.deb
+tar -xf data.tar.*
+{{end}}
+cd /tmp/kernel-download/usr/src/
+sourcedir=$(find . -type d -name "{{ .KernelHeadersPattern }}" | head -n 1 | xargs readlink -f)
 
-{{ if .BuildModule }}
-# Build the module
-make CC=/usr/bin/gcc-{{ .GCCVersion }} LD=/usr/bin/ld.bfd CROSS_COMPILE="" driver
-strip -g {{ .ModuleFullPath }}
-# Print results
-modinfo {{ .ModuleFullPath }}
-{{ end }}
-
-{{ if .BuildProbe }}
-# Build the eBPF probe
-make bpf
-ls -l driver/bpf/probe.o
-{{ end }}
+# exit value
+echo $sourcedir

--- a/pkg/driverbuilder/builder/ubuntu.go
+++ b/pkg/driverbuilder/builder/ubuntu.go
@@ -23,6 +23,9 @@ import (
 	"github.com/falcosecurity/driverkit/pkg/kernelrelease"
 )
 
+//go:embed templates/ubuntu_kernel.sh
+var ubuntuKernelTemplate string
+
 //go:embed templates/ubuntu.sh
 var ubuntuTemplate string
 
@@ -34,7 +37,6 @@ const TargetTypeUbuntu Type = "ubuntu"
 const ubuntuRequiredURLs = 2
 
 type ubuntuTemplateData struct {
-	commonTemplateData
 	KernelDownloadURLS   []string
 	KernelLocalVersion   string
 	KernelHeadersPattern string
@@ -51,6 +53,10 @@ func (v *ubuntu) Name() string {
 	return TargetTypeUbuntu.String()
 }
 
+func (v *ubuntu) TemplateKernelUrlsScript() string {
+	return ubuntuKernelTemplate
+}
+
 func (v *ubuntu) TemplateScript() string {
 	return ubuntuTemplate
 }
@@ -63,7 +69,7 @@ func (v *ubuntu) MinimumURLs() int {
 	return ubuntuRequiredURLs
 }
 
-func (v *ubuntu) TemplateData(c Config, kr kernelrelease.KernelRelease, urls []string) interface{} {
+func (v *ubuntu) KernelTemplateData(kr kernelrelease.KernelRelease, urls []string) interface{} {
 	// parse the flavor out of the kernelrelease extraversion
 	_, flavor := parseUbuntuExtraVersion(kr.Extraversion)
 
@@ -79,7 +85,6 @@ func (v *ubuntu) TemplateData(c Config, kr kernelrelease.KernelRelease, urls []s
 	}
 
 	return ubuntuTemplateData{
-		commonTemplateData:   c.toTemplateData(v, kr),
 		KernelDownloadURLS:   urls,
 		KernelLocalVersion:   kr.FullExtraversion,
 		KernelHeadersPattern: headersPattern,

--- a/pkg/driverbuilder/builder/vanilla.go
+++ b/pkg/driverbuilder/builder/vanilla.go
@@ -22,6 +22,9 @@ import (
 	"github.com/falcosecurity/driverkit/pkg/kernelrelease"
 )
 
+//go:embed templates/vanilla_kernel.sh
+var vanillaKernelTemplate string
+
 //go:embed templates/vanilla.sh
 var vanillaTemplate string
 
@@ -37,7 +40,6 @@ func init() {
 }
 
 type vanillaTemplateData struct {
-	commonTemplateData
 	KernelDownloadURL  string
 	KernelLocalVersion string
 	IsTarGz            bool
@@ -45,6 +47,10 @@ type vanillaTemplateData struct {
 
 func (v *vanilla) Name() string {
 	return TargetTypeVanilla.String()
+}
+
+func (v *vanilla) TemplateKernelUrlsScript() string {
+	return vanillaKernelTemplate
 }
 
 func (v *vanilla) TemplateScript() string {
@@ -55,9 +61,8 @@ func (v *vanilla) URLs(kr kernelrelease.KernelRelease) ([]string, error) {
 	return []string{fetchVanillaKernelURLFromKernelVersion(kr)}, nil
 }
 
-func (v *vanilla) TemplateData(c Config, kr kernelrelease.KernelRelease, urls []string) interface{} {
+func (v *vanilla) KernelTemplateData(kr kernelrelease.KernelRelease, urls []string) interface{} {
 	return vanillaTemplateData{
-		commonTemplateData: c.toTemplateData(v, kr),
 		KernelDownloadURL:  urls[0],
 		KernelLocalVersion: kr.FullExtraversion,
 		IsTarGz:            strings.HasSuffix(urls[0], ".tar.gz"), // Since RC have a tar.gz format, we need to inform the build script

--- a/pkg/driverbuilder/docker.go
+++ b/pkg/driverbuilder/docker.go
@@ -145,7 +145,7 @@ func (bp *DockerBuildProcessor) Start(b *builder.Build) error {
 		return err
 	}
 
-	kernelDownloadScript, err := builder.KernelDownloadScript(v, c, kr)
+	kernelDownloadScript, err := builder.KernelDownloadScript(v, c.KernelUrls, kr)
 	if err != nil {
 		return err
 	}

--- a/pkg/driverbuilder/kubernetes.go
+++ b/pkg/driverbuilder/kubernetes.go
@@ -101,7 +101,7 @@ func (bp *KubernetesBuildProcessor) buildModule(b *builder.Build) error {
 		return err
 	}
 
-	kernelDownloadScript, err := builder.KernelDownloadScript(v, c, kr)
+	kernelDownloadScript, err := builder.KernelDownloadScript(v, c.KernelUrls, kr)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind feature

**Any specific area of the project related to this PR?**

/area cmd
/area pkg

**What this PR does / why we need it**:

Builder script has been split in 3 different scripts:
* download libs
* download headers
* build

This way, we can reuse `download libs` script among all of them. Moreover, it is useful to have a download headers script that is invokeable by itself, because it has the logic to download and extract headers for a given distro.

Finally, fixed a couple of things with local builder:
* redirect stderr to stdout so that we catch errors too while building
* pre initialize envMap to an empty map, instead of nil
* allow to automatically download kernel headers 

Basically, what we want to achieve here is to allow `falcoctl driver loader` to be able to fetch KernelURLs using driverkit libraries, and then extract kernel urls using the newly provided templated bash scripts (note: this is a distro specific knowledge, we cannot just "untar" the headers), and finally pass the `KERNELDIR` env variable back to `local` build processor.
In the end, this approach will enable us to drop the `kernel headers` dependency for Falco installations on distros supported by driverkit, at least when the headers are actually found by driverkit itself.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

Note that ~400Locs come from new `_kernel.sh` templates licenses.

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
