### PR TITLE
new(pkg/driverbuilder): added a node selector for kubernetes executor's pod on `kubernetes.io/arch` label

### DIFF
--- a/pkg/driverbuilder/kubernetes.go
+++ b/pkg/driverbuilder/kubernetes.go
@@ -194,6 +194,7 @@ func (bp *KubernetesBuildProcessor) buildModule(b *builder.Build) error {
 			RestartPolicy:         corev1.RestartPolicyNever,
 			SecurityContext:       &secuContext,
 			ImagePullSecrets:      imagePullSecrets,
+			NodeSelector:          map[string]string{corev1.LabelArchStable: kr.Architecture.String()},
 			Containers: []corev1.Container{
 				{
 					Name:            name,
@@ -235,6 +236,10 @@ func (bp *KubernetesBuildProcessor) buildModule(b *builder.Build) error {
 			},
 		},
 	}
+
+	slog.
+		With("name", pod.Name, "spec", pod.Spec.String()).
+		Debug("starting pod")
 
 	ctx := context.Background()
 	ctx = signals.WithStandardSignals(ctx)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area pkg

**What this PR does / why we need it**:

This implements support for arm64 build for kubernetes executor.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
