### PR TITLE
fix(pkg/driverbuilder): properly export KERNELDIR in kernel-download scripts

### DIFF
--- a/pkg/driverbuilder/builder/templates/alinux_kernel.sh
+++ b/pkg/driverbuilder/builder/templates/alinux_kernel.sh
@@ -32,4 +32,4 @@ mkdir -p /tmp/kernel
 mv usr/src/kernels/*/* /tmp/kernel
 
 # exit value
-echo /tmp/kernel
+export KERNELDIR=/tmp/kernel

--- a/pkg/driverbuilder/builder/templates/almalinux_kernel.sh
+++ b/pkg/driverbuilder/builder/templates/almalinux_kernel.sh
@@ -32,4 +32,4 @@ mkdir -p /tmp/kernel
 mv usr/src/kernels/*/* /tmp/kernel
 
 # exit value
-echo /tmp/kernel
+export KERNELDIR=/tmp/kernel

--- a/pkg/driverbuilder/builder/templates/amazonlinux_kernel.sh
+++ b/pkg/driverbuilder/builder/templates/amazonlinux_kernel.sh
@@ -35,4 +35,4 @@ mkdir -p /tmp/kernel
 mv usr/src/kernels/*/* /tmp/kernel
 
 # exit value
-echo /tmp/kernel
+export KERNELDIR=/tmp/kernel

--- a/pkg/driverbuilder/builder/templates/archlinux_kernel.sh
+++ b/pkg/driverbuilder/builder/templates/archlinux_kernel.sh
@@ -32,4 +32,4 @@ mkdir -p /tmp/kernel
 mv usr/lib/modules/*/build/* /tmp/kernel
 
 # exit value
-echo /tmp/kernel
+export KERNELDIR=/tmp/kernel

--- a/pkg/driverbuilder/builder/templates/centos_kernel.sh
+++ b/pkg/driverbuilder/builder/templates/centos_kernel.sh
@@ -32,4 +32,4 @@ mkdir -p /tmp/kernel
 mv usr/src/kernels/*/* /tmp/kernel
 
 # exit value
-echo /tmp/kernel
+export KERNELDIR=/tmp/kernel

--- a/pkg/driverbuilder/builder/templates/debian_kernel.sh
+++ b/pkg/driverbuilder/builder/templates/debian_kernel.sh
@@ -38,4 +38,4 @@ sourcedir=$(find . -type d -name "{{ .KernelHeadersPattern }}" | head -n 1 | xar
 sed -i 's/\/usr\/src/../g' $sourcedir/Makefile
 
 # exit value
-echo $sourcedir
+export KERNELDIR=$sourcedir

--- a/pkg/driverbuilder/builder/templates/fedora_kernel.sh
+++ b/pkg/driverbuilder/builder/templates/fedora_kernel.sh
@@ -32,4 +32,4 @@ mkdir -p /tmp/kernel
 mv usr/src/kernels/*/* /tmp/kernel
 
 # exit value
-echo /tmp/kernel
+export KERNELDIR=/tmp/kernel

--- a/pkg/driverbuilder/builder/templates/flatcar_kernel.sh
+++ b/pkg/driverbuilder/builder/templates/flatcar_kernel.sh
@@ -39,4 +39,4 @@ make KCONFIG_CONFIG=/tmp/kernel.config oldconfig
 make KCONFIG_CONFIG=/tmp/kernel.config modules_prepare
 
 # exit value
-echo /tmp/kernel
+export KERNELDIR=/tmp/kernel

--- a/pkg/driverbuilder/builder/templates/opensuse_kernel.sh
+++ b/pkg/driverbuilder/builder/templates/opensuse_kernel.sh
@@ -34,4 +34,4 @@ cd /tmp/kernel-download/usr/src
 sourcedir="$(find . -type d -name "linux-*-obj" | head -n 1 | xargs readlink -f)/*/default"
 
 # exit value
-echo $sourcedir
+export KERNELDIR=$sourcedir

--- a/pkg/driverbuilder/builder/templates/oracle_kernel.sh
+++ b/pkg/driverbuilder/builder/templates/oracle_kernel.sh
@@ -32,4 +32,4 @@ mkdir -p /tmp/kernel
 mv usr/src/kernels/*/* /tmp/kernel
 
 # exit value
-echo /tmp/kernel
+export KERNELDIR=/tmp/kernel

--- a/pkg/driverbuilder/builder/templates/photonos_kernel.sh
+++ b/pkg/driverbuilder/builder/templates/photonos_kernel.sh
@@ -35,4 +35,4 @@ mkdir -p /tmp/kernel
 mv usr/src/linux-*headers-*/* /tmp/kernel
 
 # exit value
-echo /tmp/kernel
+export KERNELDIR=/tmp/kernel

--- a/pkg/driverbuilder/builder/templates/redhat_kernel.sh
+++ b/pkg/driverbuilder/builder/templates/redhat_kernel.sh
@@ -34,4 +34,4 @@ mkdir -p /tmp/kernel
 mv usr/src/kernels/*/* /tmp/kernel
 
 # exit value
-echo /tmp/kernel
+export KERNELDIR=/tmp/kernel

--- a/pkg/driverbuilder/builder/templates/rocky_kernel.sh
+++ b/pkg/driverbuilder/builder/templates/rocky_kernel.sh
@@ -32,4 +32,4 @@ mkdir -p /tmp/kernel
 mv usr/src/kernels/*/* /tmp/kernel
 
 # exit value
-echo /tmp/kernel
+export KERNELDIR=/tmp/kernel

--- a/pkg/driverbuilder/builder/templates/sles_kernel.sh
+++ b/pkg/driverbuilder/builder/templates/sles_kernel.sh
@@ -35,4 +35,4 @@ done
 sourcedir="$(find . -type d -name "linux-*-obj" | head -n 1 | xargs readlink -f)/*/default"
 
 # exit value
-echo $sourcedir
+export KERNELDIR=$sourcedir

--- a/pkg/driverbuilder/builder/templates/ubuntu_kernel.sh
+++ b/pkg/driverbuilder/builder/templates/ubuntu_kernel.sh
@@ -34,4 +34,4 @@ cd /tmp/kernel-download/usr/src/
 sourcedir=$(find . -type d -name "{{ .KernelHeadersPattern }}" | head -n 1 | xargs readlink -f)
 
 # exit value
-echo $sourcedir
+export KERNELDIR=$sourcedir

--- a/pkg/driverbuilder/builder/templates/vanilla_kernel.sh
+++ b/pkg/driverbuilder/builder/templates/vanilla_kernel.sh
@@ -47,4 +47,4 @@ make KCONFIG_CONFIG=/tmp/kernel.config prepare
 make KCONFIG_CONFIG=/tmp/kernel.config modules_prepare
 
 # exit value
-echo /tmp/kernel
+export KERNELDIR=/tmp/kernel

--- a/pkg/driverbuilder/docker.go
+++ b/pkg/driverbuilder/docker.go
@@ -233,6 +233,13 @@ func (bp *DockerBuildProcessor) Start(b *builder.Build) error {
 		return err
 	}
 
+	// We make all 3 scripts executables,
+	// then:
+	// * download libs at required version
+	// * download and extract headers
+	//   * each download-headers script will export KERNELDIR variable internally
+	//   * we source download-headers.sh so that KERNELDIR is then visible to driverkit.sh
+	// * we finally make the actual build of the drivers
 	runCmd :=
 		`
 #!/bin/bash
@@ -242,7 +249,8 @@ chmod +x /driverkit/download-headers.sh
 chmod +x /driverkit/driverkit.sh
 
 /driverkit/download-libs.sh
-KERNELDIR=$(/driverkit/download-headers.sh) /driverkit/driverkit.sh
+. /driverkit/download-headers.sh
+/driverkit/driverkit.sh
 `
 
 	files := []dockerCopyFile{

--- a/pkg/driverbuilder/kubernetes.go
+++ b/pkg/driverbuilder/kubernetes.go
@@ -113,9 +113,9 @@ func (bp *KubernetesBuildProcessor) buildModule(b *builder.Build) error {
 	}
 
 	// We run a script that downloads libs,
-	// download and extracts kernelURLs saving its output to KERNELDIR env variable,
+	// then downloads and extracts kernelURLs exporting KERNELDIR env variable,
 	// then finally runs the build script.
-	res = fmt.Sprintf("%s\nexport KERNELDIR=$(%s)\n%s", libsDownloadScript, kernelDownloadScript, res)
+	res = fmt.Sprintf("%s\n%s\n%s", libsDownloadScript, kernelDownloadScript, res)
 
 	if c.ModuleFilePath != "" {
 		res = fmt.Sprintf("%s\n%s", "touch "+moduleLockFile, res)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area pkg

**What this PR does / why we need it**:

Fix on top of #324 (this comment was highly specific: https://github.com/falcosecurity/driverkit/pull/324#discussion_r1524730462 :D)
It also fixes vanilla kernel builds; see libs CI that is badly failing since we released driverkit v0.18.0: https://github.com/falcosecurity/libs/actions/workflows/latest-kernel.yml

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
