### PR TITLE
fix(pkg/driverbuilder): fixed local builder template.

### DIFF
--- a/pkg/driverbuilder/builder/templates/local.sh
+++ b/pkg/driverbuilder/builder/templates/local.sh
@@ -20,7 +20,7 @@
 # looking for it in a bunch of ways. Convenient when running Falco inside
 # a container or in other weird environments.
 #
-set -xeuo pipefail
+set -xeo pipefail
 
 {{ if or .BuildProbe (and  .BuildModule (not .UseDKMS)) }}
 cd {{ .DriverBuildDir }}

--- a/pkg/driverbuilder/local.go
+++ b/pkg/driverbuilder/local.go
@@ -74,7 +74,7 @@ func (lbp *LocalBuildProcessor) Start(b *builder.Build) error {
 		// if an unsupported target is passed.
 		// Go on skipping automatic kernel headers download.
 		if err == nil {
-			lbp.Logger.Info("Trying automatic kernel headers download")
+			lbp.Logger.Info("Trying automatic kernel headers download.")
 			kernelDownloadScript, err := builder.KernelDownloadScript(realBuilder, nil, kr, lbp.Printer)
 			// Patch kernel download script to echo KERNELDIR.
 			// We need to capture KERNELDIR to later pass it as env variable to the build.
@@ -90,7 +90,7 @@ func (lbp *LocalBuildProcessor) Start(b *builder.Build) error {
 					for scanner.Scan() {
 						path = scanner.Text()
 					}
-					lbp.Logger.Info("Setting KERNELDIR env var", lbp.Logger.Args("path", path))
+					lbp.Logger.Info("Setting KERNELDIR env var.", lbp.Logger.Args("path", path))
 					// add the kerneldir path to env
 					lbp.envMap[kernelDirEnv] = path
 					defer func() {
@@ -98,11 +98,11 @@ func (lbp *LocalBuildProcessor) Start(b *builder.Build) error {
 						_ = os.RemoveAll(path)
 					}()
 				} else {
-					lbp.Logger.Warn("Failed to download headers", lbp.Logger.Args("err", err))
+					lbp.Logger.Warn("Failed to download headers.", lbp.Logger.Args("err", err))
 				}
 			}
 		} else {
-			lbp.Logger.Info("Skipping kernel headers automatic download", lbp.Logger.Args("err", err))
+			lbp.Logger.Info("Skipping kernel headers automatic download.", lbp.Logger.Args("err", err))
 		}
 	}
 
@@ -202,7 +202,7 @@ func (lbp *LocalBuildProcessor) Start(b *builder.Build) error {
 				if err = copyDataToLocalPath(srcProbePath, c.ProbeFilePath); err != nil {
 					return err
 				}
-				lbp.Logger.Info("eBPF probe available", lbp.Logger.Args("path", c.ProbeFilePath))
+				lbp.Logger.Info("eBPF probe available.", lbp.Logger.Args("path", c.ProbeFilePath))
 				c.ProbeFilePath = ""
 			}
 		}
@@ -218,7 +218,7 @@ func (lbp *LocalBuildProcessor) Start(b *builder.Build) error {
 				if err = copyDataToLocalPath(koFiles[0], c.ModuleFilePath); err != nil {
 					return err
 				}
-				lbp.Logger.Info("kernel module available", lbp.Logger.Args("path", b.ModuleFilePath))
+				lbp.Logger.Info("kernel module available.", lbp.Logger.Args("path", b.ModuleFilePath))
 				c.ModuleFilePath = ""
 				break
 			} else {
@@ -226,7 +226,7 @@ func (lbp *LocalBuildProcessor) Start(b *builder.Build) error {
 				dkmsLogFile := fmt.Sprintf("/var/lib/dkms/%s/%s/build/make.log", c.DriverName, c.DriverVersion)
 				logs, err := os.ReadFile(filepath.Clean(dkmsLogFile))
 				if err != nil {
-					lbp.Logger.Warn("Running dkms build failed, couldn't find dkms log", lbp.Logger.Args("file", dkmsLogFile))
+					lbp.Logger.Warn("Running dkms build failed, couldn't find dkms log.", lbp.Logger.Args("file", dkmsLogFile))
 				} else {
 					lbp.Logger.Warn("Running dkms build failed. Dumping dkms log.", lbp.Logger.Args("file", dkmsLogFile))
 					logBuf := bytes.NewBuffer(logs)
@@ -241,7 +241,7 @@ func (lbp *LocalBuildProcessor) Start(b *builder.Build) error {
 	}
 
 	if c.ModuleFilePath != "" || c.ProbeFilePath != "" {
-		return fmt.Errorf("Failed to build all requested drivers.")
+		return errors.New("failed to build all requested drivers")
 	}
 	return nil
 }

--- a/pkg/driverbuilder/local.go
+++ b/pkg/driverbuilder/local.go
@@ -38,6 +38,9 @@ func NewLocalBuildProcessor(useDKMS, downloadHeaders, printOnError bool,
 	envMap map[string]string,
 	timeout int,
 ) *LocalBuildProcessor {
+	if envMap == nil {
+		envMap = make(map[string]string)
+	}
 	return &LocalBuildProcessor{
 		useDKMS:         useDKMS,
 		srcDir:          srcDir,


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area pkg

**What this PR does / why we need it**:

Fix on top of #342: remove `-u` flag from local template `set` bash command, since we reference unexisting env var in the template, and it would lead to failure: 
> -u
>
>    Treat unset variables and parameters other than the special parameters ‘@’ or ‘*’, or array variables subscripted with ‘@’ or ‘*’, as an error when performing parameter expansion. An error message will be written to the standard error, and a non-interactive shell will exit.


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
