### PR TITLE
fix(docker): fixed centos7 builder because of EoL.

### DIFF
--- a/docker/builders/builder-centos-x86_64_gcc4.8.5.Dockerfile
+++ b/docker/builders/builder-centos-x86_64_gcc4.8.5.Dockerfile
@@ -2,8 +2,19 @@ FROM centos:7
 
 LABEL maintainer="cncf-falco-dev@lists.cncf.io"
 
-RUN yum -y install centos-release-scl && \
-    yum -y install gcc \
+# Fix broken mirrors - centos:7 eol
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo; \
+    sed -i s/^#.*baseurl=http/baseurl=https/g /etc/yum.repos.d/*.repo; \
+    sed -i s/^mirrorlist=http/#mirrorlist=https/g /etc/yum.repos.d/*.repo
+
+RUN yum -y install centos-release-scl
+
+# fix broken mirrors (again)
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo; \
+    sed -i s/^#.*baseurl=http/baseurl=https/g /etc/yum.repos.d/*.repo; \
+    sed -i s/^mirrorlist=http/#mirrorlist=https/g /etc/yum.repos.d/*.repo
+
+RUN yum -y install gcc \
     llvm-toolset-7.0 \
 	bash-completion \
 	bc \


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

Since centos7 is now EoL, we need to swap the centos7 builder repo to the `vault.centos.org` archive.
Also, fixes master CI.

**Which issue(s) this PR fixes**:


Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
