### PR TITLE
fix(pkg/kernelrelease): fixed kernelrelease regex for weird COS kernels.

### DIFF
--- a/pkg/kernelrelease/kernelrelease.go
+++ b/pkg/kernelrelease/kernelrelease.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	kernelVersionPattern = regexp.MustCompile(`(?P<fullversion>^(?P<version>0|[1-9]\d*)\.(?P<patchlevel>0|[1-9]\d*)[.+]?(?P<sublevel>0|[1-9]\d*)?)(?P<fullextraversion>[-.+](?P<extraversion>\d+|\d*[a-zA-Z-][0-9a-zA-Z-]*)([\.+~](\d+|\d*[a-zA-Z-][0-9a-zA-Z-_]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$`)
+	kernelVersionPattern = regexp.MustCompile(`(?P<fullversion>^(?P<version>0|[1-9]\d*)\.(?P<patchlevel>0|[1-9]\d*)[.+]?(?P<sublevel>0|[1-9]\d*)?)(?P<fullextraversion>[-.+](?P<extraversion>\d+|\d*[a-zA-Z-][0-9a-zA-Z-]*)?([\.+~](\d+|\d*[a-zA-Z-][0-9a-zA-Z-_]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$`)
 )
 
 const (

--- a/pkg/kernelrelease/kernelrelease_test.go
+++ b/pkg/kernelrelease/kernelrelease_test.go
@@ -248,11 +248,26 @@ func TestFromString(t *testing.T) {
 				FullExtraversion: "-19.0009.28",
 			},
 		},
+		// See https://github.com/falcosecurity/falco/issues/3278
+		"strange cos version": {
+			kernelVersionStr: "5.15.146+",
+			want: KernelRelease{
+				Fullversion: "5.15.146",
+				Version: semver.Version{
+					Major: 5,
+					Minor: 15,
+					Patch: 146,
+				},
+				Extraversion:     "",
+				FullExtraversion: "+",
+			},
+		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := FromString(tt.kernelVersionStr)
 			assert.DeepEqual(t, tt.want, got)
+			assert.Equal(t, got.String(), tt.kernelVersionStr)
 		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area pkg

**What this PR does / why we need it**:

COS kernels have `5.10.6+` form, that was previously not allowed by our regex. Fix it.
Refs: https://github.com/falcosecurity/falco/issues/3278

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
fix(pkg/kernelrelease): fixed kernelrelease regex for weird COS kernels.
```
