### PR TITLE
new(docker): add a `any` distro gcc 14.0.0 image.

### DIFF
--- a/docker/builders/builder-any-aarch64_gcc14.0.0.Dockerfile
+++ b/docker/builders/builder-any-aarch64_gcc14.0.0.Dockerfile
@@ -1,0 +1,1 @@
+builder-any-x86_64_gcc14.0.0.Dockerfile

--- a/docker/builders/builder-any-x86_64_gcc14.0.0.Dockerfile
+++ b/docker/builders/builder-any-x86_64_gcc14.0.0.Dockerfile
@@ -1,0 +1,40 @@
+FROM fedora:41
+
+LABEL maintainer="cncf-falco-dev@lists.cncf.io"
+
+ARG TARGETARCH
+
+RUN dnf install -y \
+	bash-completion \
+	bc \
+	clang \
+	llvm \
+	ca-certificates \
+	curl \
+	dkms \
+	dwarves \
+	gnupg2 \
+	gcc \
+	jq \
+	glibc-devel \
+	elfutils-libelf-devel \
+	netcat \
+	xz \
+	cpio \
+	flex \
+	bison \
+	openssl \
+	openssl-devel \
+	ncurses-devel \
+	systemd-devel \
+	pciutils-devel \
+	binutils-devel \
+	lsb-release \
+	wget \
+	gpg \
+	zstd \
+	cmake \
+	git
+
+# Properly create soft links
+RUN ln -s /usr/bin/gcc /usr/bin/gcc-14.0.0

--- a/docker/builders/builder-arch-x86_64_gcc14.2.1.Dockerfile
+++ b/docker/builders/builder-arch-x86_64_gcc14.2.1.Dockerfile
@@ -1,9 +1,0 @@
-FROM archlinux:base-devel-20250119.0.299327
-
-LABEL maintainer="cncf-falco-dev@lists.cncf.io"
-
-RUN pacman -Sy && pacman -Sy --noconfirm cmake pahole clang llvm git cpio wget openssl bc
-
-
-# Properly create soft link
-RUN ln -s /usr/bin/gcc /usr/bin/gcc-14.2.1

--- a/pkg/driverbuilder/builder/builders.go
+++ b/pkg/driverbuilder/builder/builders.go
@@ -220,8 +220,8 @@ type GCCVersionRequestor interface {
 func defaultGCC(kr kernelrelease.KernelRelease) semver.Version {
 	switch kr.Major {
 	case 6:
-		if kr.Minor >= 10 {
-			return semver.Version{Major: 14, Minor: 2, Patch: 1}
+		if kr.Minor >= 9 {
+			return semver.Version{Major: 14}
 		}
 		if kr.Minor >= 5 {
 			return semver.Version{Major: 13}
@@ -242,7 +242,7 @@ func defaultGCC(kr kernelrelease.KernelRelease) semver.Version {
 	case 2:
 		return semver.Version{Major: 4, Minor: 8}
 	default:
-		return semver.Version{Major: 14, Minor: 2, Patch: 1}
+		return semver.Version{Major: 14}
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area pkg

**What this PR does / why we need it**:

In https://github.com/falcosecurity/driverkit/pull/372, we added an archlinux specific gcc 14 image to fix drivers build against linux >= 6.10.
It turned out, that change is not archlinux specific but is an upstream change: https://lore.kernel.org/lkml/ZdXVk41lSMLx_Fmg@FVFF77S0Q05N/

This is why our drivers pipeline is failing for ubuntu 6.11 (and probably many more recent drivers).
Thus, i added an `any`-distro gcc 14 image; also, dropped archlinux-specific gcc14.0.0 image.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
new(docker): add an any-distro gcc 14.0.0 image.
```
