### PR TITLE
fix(docker): fixed buster builder docker image.

### DIFF
--- a/docker/builders/builder-any-x86_64_gcc8.0.0_gcc6.0.0_gcc5.0.0_gcc4.9.0_gcc4.8.0.Dockerfile
+++ b/docker/builders/builder-any-x86_64_gcc8.0.0_gcc6.0.0_gcc5.0.0_gcc4.9.0_gcc4.8.0.Dockerfile
@@ -6,6 +6,13 @@ ARG TARGETARCH
 
 RUN cp /etc/skel/.bashrc /root && cp /etc/skel/.profile /root
 
+# Use 20250630T203427Z debian apt snapshot as it still contains support for buster.
+RUN cat <<EOF > /etc/apt/sources.list
+deb http://snapshot.debian.org/archive/debian/20250630T203427Z buster main
+deb http://snapshot.debian.org/archive/debian-security/20250630T203427Z buster/updates main
+deb http://snapshot.debian.org/archive/debian/20250630T203427Z buster-updates main
+EOF
+
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
 	bash-completion \


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

As buster reached its EOL, the official debian repo URL doesn't host anymore buster packages info. For this reason, pin to the `20250630T203427Z` snapshot, which still contains them.
Same as https://github.com/falcosecurity/falco/pull/3644 for driverkit.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
fix(docker): fixed buster builder docker image.
```
