### PR TITLE
fix(kernelrelease): fix parsing for kern ver specifying just the major

### DIFF
--- a/pkg/kernelrelease/kernelrelease.go
+++ b/pkg/kernelrelease/kernelrelease.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	kernelVersionPattern = regexp.MustCompile(`(?P<fullversion>^(?P<version>0|[1-9]\d*)\.(?P<patchlevel>0|[1-9]\d*)[.+]?(?P<sublevel>0|[1-9]\d*)?)(?P<fullextraversion>[-.+](?P<extraversion>\d+|\d*[a-zA-Z-][0-9a-zA-Z-]*)?([\.+~](\d+|\d*[a-zA-Z-][0-9a-zA-Z-_]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$`)
+	kernelVersionPattern = regexp.MustCompile(`(?P<fullversion>^(?P<version>0|[1-9]\d*)(?:\.(?P<patchlevel>0|[1-9]\d*)[.+]?(?P<sublevel>0|[1-9]\d*)?)?)(?P<fullextraversion>[-.+](?P<extraversion>\d+|\d*[a-zA-Z-][0-9a-zA-Z-]*)?([\.+~](\d+|\d*[a-zA-Z-][0-9a-zA-Z-_]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$`)
 )
 
 const (
@@ -110,7 +110,9 @@ func FromString(kernelVersionStr string) KernelRelease {
 			case "version":
 				kv.Major, err = strconv.ParseUint(match[i], 10, 64)
 			case "patchlevel":
-				kv.Minor, err = strconv.ParseUint(match[i], 10, 64)
+				if len(match[i]) > 0 {
+					kv.Minor, err = strconv.ParseUint(match[i], 10, 64)
+				}
 			case "sublevel":
 				if len(match[i]) > 0 {
 					// We accept a missing sublevel (defaulting to 0)

--- a/pkg/kernelrelease/kernelrelease_test.go
+++ b/pkg/kernelrelease/kernelrelease_test.go
@@ -40,6 +40,17 @@ func TestFromString(t *testing.T) {
 				FullExtraversion: "-arch1-1",
 			},
 		},
+		"just major version": {
+			kernelVersionStr: "7",
+			want: KernelRelease{
+				Fullversion: "7",
+				Version: semver.Version{
+					Major: 7,
+				},
+				Extraversion:     "",
+				FullExtraversion: "",
+			},
+		},
 		"version RC": {
 			kernelVersionStr: "6.4-rc1",
 			want: KernelRelease{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area cmd

/area pkg

> /area docs

> /area tests


**What this PR does / why we need it**:

This PR allows parsing kernel version string specifying just the major number, like "7". Notice that this is required in order to be flexible to situations in which the user specifies something like 7.0 (unquoted) in the configuration and the YAML parser drops the ".0" while converting the value (recognized as a float number) to string.

The aforementioned example is taken from here: https://github.com/falcosecurity/libs/actions/runs/24333996573

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
